### PR TITLE
Add CI/CD pipelines, release automation and chart wiring

### DIFF
--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -1,0 +1,40 @@
+name: chart-release
+
+on:
+  push:
+    tags:
+      - 'chart/v*'
+
+permissions:
+  contents: read
+  packages: write   # push chart to ghcr.io OCI registry
+
+jobs:
+  chart-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: azure/setup-helm@v4
+
+      - name: Resolve chart version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#chart/v}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to ghcr.io
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io --username "${{ github.actor }}" --password-stdin
+
+      - name: Lint chart
+        run: helm lint dist/chart
+
+      - name: Package chart
+        env:
+          CHART_VERSION: ${{ steps.version.outputs.version }}
+        # appVersion is taken from the committed Chart.yaml (drives the default image tag);
+        # only the packaging version comes from the tag.
+        run: helm package dist/chart --version "$CHART_VERSION"
+
+      - name: Push chart to ghcr.io
+        env:
+          CHART_VERSION: ${{ steps.version.outputs.version }}
+        run: helm push "kube-vim-${CHART_VERSION}.tgz" oci://ghcr.io/kube-nfv/charts

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,86 @@
+name: ci
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  # TODO(#23): re-enable once golangci-lint is migrated to v2 (Go 1.25 support)
+  # and the existing findings are resolved. When re-enabling, add `lint` back to
+  # the `ci` gate's `needs` below.
+  # lint:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: actions/setup-go@v5
+  #       with:
+  #         go-version-file: go.mod
+  #         cache: true
+  #     - name: make lint
+  #       run: make lint
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: make build
+        run: make build
+      - name: Verify generated/formatted code is committed
+        run: |
+          if ! git diff --exit-code; then
+            echo "::error::'make build' produced changes. Run 'make generate' and 'make fmt' and commit the result."
+            exit 1
+          fi
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: make test
+        run: make test
+
+  helm-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: azure/setup-helm@v4
+      - name: helm lint
+        run: helm lint dist/chart
+      - name: Require chart version bump when chart changes
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          if git diff --quiet "$BASE_SHA"...HEAD -- dist/chart; then
+            echo "No chart changes; skipping version-bump check."
+            exit 0
+          fi
+          old_ver=$(git show "$BASE_SHA":dist/chart/Chart.yaml | awk '/^version:/ {print $2; exit}')
+          new_ver=$(awk '/^version:/ {print $2; exit}' dist/chart/Chart.yaml)
+          echo "chart version: $old_ver -> $new_ver"
+          if [ "$old_ver" = "$new_ver" ]; then
+            echo "::error::dist/chart changed but Chart.yaml 'version' was not bumped."
+            exit 1
+          fi
+
+  # Single required status check aggregating the jobs above.
+  # Branch protection on main requires the "ci" context.
+  ci:
+    runs-on: ubuntu-latest
+    needs: [build, test, helm-lint]  # add `lint` once the lint job is re-enabled
+    steps:
+      - run: echo "all checks passed"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,68 @@
+name: release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write   # create GitHub Release + upload assets
+  packages: write   # push images to ghcr.io
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      REGISTRY: ghcr.io
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Resolve version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build images
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: make docker-build KUBEVIM_VERSION="$VERSION" KUBEVIM_GATEWAY_VERSION="$VERSION"
+
+      - name: Push images
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          for img in kube-vim gateway; do
+            docker push "ghcr.io/kube-nfv/$img:$VERSION"
+            docker tag  "ghcr.io/kube-nfv/$img:$VERSION" "ghcr.io/kube-nfv/$img:latest"
+            docker push "ghcr.io/kube-nfv/$img:latest"
+          done
+
+      - name: Build binaries
+        run: make build
+
+      - name: Stage release binaries
+        run: |
+          mkdir -p release
+          cp bin/kube-vim release/kube-vim-linux-amd64
+          cp bin/gateway release/gateway-linux-amd64
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --title "$GITHUB_REF_NAME" \
+            --generate-notes \
+            release/kube-vim-linux-amd64 \
+            release/gateway-linux-amd64

--- a/README.md
+++ b/README.md
@@ -110,10 +110,15 @@ Binaries are written to `bin/`. Build dependency tools are installed under `bin/
 
 ## Deployment
 
-kube-vim is deployed with the Helm chart in [`dist/chart`](dist/chart):
+kube-vim is deployed with the Helm chart in [`dist/chart`](dist/chart), either from a local
+checkout or from the published OCI chart:
 
 ```bash
+# from the repo
 helm install kube-vim ./dist/chart -n kube-vim --create-namespace
+
+# from the OCI registry (published on chart/v* tags)
+helm install kube-vim oci://ghcr.io/kube-nfv/charts/kube-vim -n kube-vim --create-namespace
 ```
 
 Both components read configuration loaded by [Viper](https://github.com/spf13/viper) from a
@@ -145,6 +150,7 @@ API** (outside the ETSI reference points) handles image management tasks.
 - [docs/management-network.md](docs/management-network.md) — managed management network design & runbook
 - [docs/sriov-networks.md](docs/sriov-networks.md) — SR-IOV networks design & runbook
 - [docs/monitoring.md](docs/monitoring.md) — telemetry / metrics design & runbook
+- [docs/ci-cd.md](docs/ci-cd.md) — CI/CD workflows, release management & runbook
 
 ## License
 

--- a/dist/chart/Chart.yaml
+++ b/dist/chart/Chart.yaml
@@ -1,4 +1,7 @@
 apiVersion: v2
 name: kube-vim
 description: A Helm chart for Kube-NFV kube-vim installation
-version: 0.0.1 # TODO: Change it in future
+version: 0.0.1 # chart packaging version; bump on any chart change, released via chart/v* tag
+# App release the chart deploys by default. Drives the image tag (see _helpers.tpl).
+# Bump manually to a published kube-vim release before cutting a chart release.
+appVersion: "0.0.1"

--- a/dist/chart/Chart.yaml
+++ b/dist/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: kube-vim
 description: A Helm chart for Kube-NFV kube-vim installation
-version: 0.0.1 # chart packaging version; bump on any chart change, released via chart/v* tag
+version: 0.0.2 # chart packaging version; bump on any chart change, released via chart/v* tag
 # App release the chart deploys by default. Drives the image tag (see _helpers.tpl).
 # Bump manually to a published kube-vim release before cutting a chart release.
 appVersion: "0.0.1"

--- a/dist/chart/templates/_helpers.tpl
+++ b/dist/chart/templates/_helpers.tpl
@@ -107,7 +107,7 @@ Return the proper image name for VIM
 {{- define "kube-vim.vim.image" -}}
 {{- $registry := .Values.global.image.registry -}}
 {{- $repository := .Values.vim.image.repository -}}
-{{- $tag := .Values.vim.image.tag | default .Values.global.image.tag -}}
+{{- $tag := .Values.vim.image.tag | default .Values.global.image.tag | default .Chart.AppVersion -}}
 {{- printf "%s/%s:%s" $registry $repository $tag -}}
 {{- end }}
 
@@ -117,7 +117,7 @@ Return the proper image name for Gateway
 {{- define "kube-vim.gateway.image" -}}
 {{- $registry := .Values.global.image.registry -}}
 {{- $repository := .Values.gateway.image.repository -}}
-{{- $tag := .Values.gateway.image.tag | default .Values.global.image.tag -}}
+{{- $tag := .Values.gateway.image.tag | default .Values.global.image.tag | default .Chart.AppVersion -}}
 {{- printf "%s/%s:%s" $registry $repository $tag -}}
 {{- end }}
 

--- a/dist/chart/values.yaml
+++ b/dist/chart/values.yaml
@@ -6,7 +6,9 @@
 global:
   image:
     registry: ghcr.io/kube-nfv
-    tag: "latest"
+    # Empty by default so the image tag falls back to the chart's appVersion.
+    # Override to pin a specific image tag across all components.
+    tag: ""
     pullPolicy: IfNotPresent
     pullSecrets: []
 

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -1,0 +1,102 @@
+# CI/CD and Release Management
+
+Status: accepted (2026-07-03)
+Owner: kube-vim
+Scope: GitHub Actions, container/chart publishing, branch protection
+
+## TL;DR
+
+Three GitHub Actions workflows drive validation and releases, all delegating to
+the `make` targets so CI mirrors local development:
+
+- **`ci`** — runs on every PR and push to `main`: `build` (+ generated/formatted
+  code is committed), `test`, and `helm-lint`. A no-op `ci` gate job aggregates
+  them and is the single required status check on `main`.
+- **`release`** — runs on a `v*` tag: builds and pushes both images to
+  `ghcr.io/kube-nfv`, then cuts a GitHub Release with binaries.
+- **`chart-release`** — runs on a `chart/v*` tag: packages the Helm chart and
+  pushes it as an OCI artifact to `ghcr.io/kube-nfv/charts`.
+
+The app and the chart release **independently**. The only link between them is
+the chart's `appVersion`, bumped by hand in a reviewed PR.
+
+## Problem
+
+The repo had no CI: nothing ran on PRs, images and charts were built by hand,
+and there was no release automation. Nothing stopped a broken change or a direct
+push to `main`, and "releases come from git tags" was a convention with no
+tooling behind it.
+
+## Decisions
+
+### `make` targets are the single source of truth
+
+Workflows call `make build`, `make test`, `make docker-build`, etc. rather than
+re-implementing build logic in YAML. What passes locally passes in CI, and there
+is one place to change build behaviour.
+
+### App and chart release independently
+
+An app release and a chart release answer different questions ("what code runs"
+vs "how it is packaged and deployed") and change at different cadences. Coupling
+them into one tag would force a chart bump on every app release and vice versa.
+
+- App release: tag `v1.2.3` → images `ghcr.io/kube-nfv/{kube-vim,gateway}:1.2.3`
+  (+ `:latest`), binaries, and a GitHub Release. The chart is untouched.
+- Chart release: tag `chart/v0.1.0` → `helm package` + OCI push. No image build.
+
+Neither workflow triggers the other.
+
+### `appVersion` is the chart↔app link, set manually
+
+`Chart.yaml`'s `appVersion` names the app release the chart deploys by default.
+The image tag in the templates falls back to it:
+
+```
+tag := .Values.<svc>.image.tag | default .Values.global.image.tag | default .Chart.AppVersion
+```
+
+`global.image.tag` is empty by default, so bumping `appVersion` repoints the
+default image with no package-time mutation, while users can still override the
+tag. `appVersion` is bumped by hand in a reviewed PR, deliberately: a chart
+should only claim an app version it has actually been rendered/tested against,
+and a chart must never reference an image tag that has not been published yet.
+Chart releases therefore **follow** app releases.
+
+### Branch protection on `main`
+
+`main` requires a PR (direct pushes blocked), the `ci` check to pass and be
+up to date, linear history, and conversation resolution; force-pushes and
+deletion are blocked. Configured via the GitHub API (not a committed file).
+
+## Operator runbook
+
+### Cut an app release
+
+1. Merge the code to `main`.
+2. Tag and push: `git tag v1.2.3 && git push origin v1.2.3`.
+3. The `release` workflow publishes the images, binaries, and GitHub Release.
+
+### Cut a chart release
+
+1. In a PR, bump `Chart.yaml` `version` (packaging version, always) and, if
+   retargeting the app, `appVersion` to an **already-published** app tag.
+2. Merge to `main`.
+3. Tag and push: `git tag chart/v0.1.0 && git push origin chart/v0.1.0`.
+   The `chart-release` workflow packages and pushes the chart to
+   `oci://ghcr.io/kube-nfv/charts`.
+
+### Ship a new app version via Helm
+
+App and chart are decoupled, so this is two steps: cut the app release, then a
+chart release whose `appVersion` points at it.
+
+## Known gaps / follow-ups
+
+- **Lint is not yet in CI.** golangci-lint is pinned to a version that cannot
+  parse Go 1.25; migrating to v2 surfaces a backlog of findings. The `lint` job
+  is present but commented out in `ci.yaml`; re-add it to the `ci` gate once the
+  migration and cleanup land (tracked in #23).
+- **Single-arch images.** Images are built for the runner's architecture
+  (amd64). Multi-arch (amd64/arm64) and e2e via `make kind-install` are planned
+  follow-ups.

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -74,7 +74,7 @@ type ErrK8sObjectNotInstantiated struct {
 
 func (e *ErrK8sObjectNotInstantiated) Error() string {
 	if e.Identifier == "" {
-		e.Identifier = "unknown"
+		return fmt.Sprintf("%s is not from Kubernetes (likely created manually)", e.ObjectType)
 	}
 	return fmt.Sprintf("%s (id: %s) is not from Kubernetes (likely created manually)", e.ObjectType, e.Identifier)
 }


### PR DESCRIPTION
Closes #20.

Adds GitHub Actions covering validation and releases, all delegating to the `make` targets so CI mirrors local development. Branch protection on `main` (require PR, block direct pushes, required `ci` check, linear history) was applied out-of-band via the GitHub API.

## Workflows
- **`ci`** — on PRs and pushes to `main`: `build` (+ a check that `make build` leaves no generated/formatted diff), `test`, and `helm-lint`. A no-op `ci` gate job aggregates them and is the single required status check.
- **`release`** — on `v*` tags: builds and pushes both images to `ghcr.io/kube-nfv` (`:<version>` + `:latest`), attaches binaries, and cuts a GitHub Release.
- **`chart-release`** — on `chart/v*` tags: packages the Helm chart and pushes it as an OCI artifact to `ghcr.io/kube-nfv/charts`.

App and chart release independently; the only link is the chart's `appVersion`, bumped by hand in a reviewed PR.

## Chart wiring
`Chart.yaml` gains `appVersion`, `global.image.tag` defaults to empty, and the image helpers fall back to `.Chart.AppVersion`. Bumping `appVersion` repoints the default image with no package-time mutation, still overridable.

## Incidental fix
`ErrK8sObjectNotInstantiated.Error()` no longer emits `(id: unknown)` or mutates its receiver when no identifier is set — was failing `make test`.

## Docs
- `docs/ci-cd.md` — workflows, the app/chart decoupling decision, and an operator runbook.
- README — OCI chart install option + doc link.

## Deferred
Lint is not yet wired into CI: golangci-lint is pinned to a version that can't parse Go 1.25, and migrating to v2 surfaces a backlog. The `lint` job is left commented in `ci.yaml` and tracked in #23. Multi-arch images and e2e via `make kind-install` remain follow-ups.