### PR TITLE
Add pci_address, host_id and pod_name join keys to kube-vim info metrics

### DIFF
--- a/dist/chart/Chart.yaml
+++ b/dist/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: kube-vim
 description: A Helm chart for Kube-NFV kube-vim installation
-version: 0.0.4 # chart packaging version; bump on any chart change, released via chart/v* tag
+version: 0.0.5 # chart packaging version; bump on any chart change, released via chart/v* tag
 # App release the chart deploys by default. Drives the image tag (see _helpers.tpl).
 # Bump manually to a published kube-vim release before cutting a chart release.
 appVersion: "0.0.1"

--- a/dist/chart/templates/role.yaml
+++ b/dist/chart/templates/role.yaml
@@ -43,6 +43,13 @@ rules:
   - secrets
   verbs:
   - "*"
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/dist/manifests/kubevim.yaml
+++ b/dist/manifests/kubevim.yaml
@@ -76,6 +76,13 @@ rules:
   - virtualmachineinstances
   verbs:
   - "*"
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -54,12 +54,50 @@ Correlation (value always `1`):
 
 | Metric | Key labels |
 |---|---|
-| `kubevim_compute_info` | `compute_id`, `compute_name`, `flavour_id`, `image_id`, `host_id`, `operational_state`, `running_state` |
-| `kubevim_vnic_info` | `compute_id`, `compute_name`, `vnic_id`, `network_id`, `subnet_id`, `network_port_id`, `type` |
+| `kubevim_compute_info` | `compute_id`, `compute_name`, `flavour_id`, `image_id`, `host_id`, `pod_name`, `operational_state`, `running_state` |
+| `kubevim_vnic_info` | `compute_id`, `compute_name`, `vnic_id`, `network_id`, `subnet_id`, `network_port_id`, `type`, `host_id`, `pci_address` |
 | `kubevim_network_info` | `network_id`, `network_name`, `network_type`, `provider_network`, `segmentation_id`, `operational_state` |
 
 `compute_name` equals the KubeVirt VM/VMI name — the join key to the `name` label
-on `kubevirt_vmi_*`. `compute_id` is the ETSI compute id (the VM UID).
+on `kubevirt_vmi_*`. `compute_id` is the ETSI compute id (the VM UID). `pod_name` is
+the virt-launcher pod — the join key to pod-scoped series (cAdvisor `container_*`,
+kube-state-metrics `kube_pod_*`) that `kubevirt_vmi_*` does not cover.
+
+On `kubevim_vnic_info`, two labels make a vNIC deterministically joinable to its
+backend counters:
+
+- `pci_address` — the **host** VF/pass-through PCI address of a host-PCI vNIC
+  (`type=TYPE_VIRTUAL_NIC_SRIOV`); the join key to the SR-IOV VF exporter's
+  `sriov_vf_*{pciAddr}` series. Empty for virtio/bridge vNICs. Sourced from the
+  virt-launcher pod's `kubevirt.io/network-info` annotation.
+- `host_id` — the node name (matches `kubevim_compute_info.host_id`). Keeps the
+  `pci_address` join unambiguous: PCI addresses are node-local, not cluster-unique.
+
+`pod_name`/`pci_address` are read best-effort from the virt-launcher pod on each
+scrape; if the pod or annotation is absent the labels are empty and the scrape still
+succeeds. The `kubevirt.io/network-info` payload type is redefined locally
+(`internal/kubevim/compute/kubevirt`) rather than imported — the upstream type sits
+in the `kubevirt.io/kubevirt` application module, which is not consumable as a
+library (kube-vim depends only on the `kubevirt.io/api` / `client-go` staging modules).
+
+Bridge/virtio vNICs need no extra label: KubeVirt sets the `interface` label on
+`kubevirt_vmi_network_*` to the network name, which equals `vnic_id`, so the join
+keys on `vnic_id` directly. (SR-IOV VF traffic bypasses virtio and never appears in
+`kubevirt_vmi_network_*`.)
+
+```promql
+# SR-IOV VF counters → ETSI compute/vNIC
+sriov_vf_rx_packets
+  * on(pciAddr) group_left(compute_id, vnic_id)
+  label_replace(kubevim_vnic_info{type="TYPE_VIRTUAL_NIC_SRIOV"},
+                "pciAddr", "$1", "pci_address", "(.+)")
+
+# bridge/virtio counters → ETSI compute/vNIC
+kubevirt_vmi_network_receive_packets_total
+  * on(name, interface) group_left(compute_id, vnic_id)
+  label_replace(label_replace(kubevim_vnic_info{type="TYPE_VIRTUAL_NIC_BRIDGE"},
+      "name", "$1", "compute_name", "(.+)"), "interface", "$1", "vnic_id", "(.+)")
+```
 
 The gauges are OTEL observable gauges whose callback reuses the domain managers'
 existing `List*` methods (`compute.Manager.ListComputeResources`,
@@ -117,6 +155,8 @@ pod annotations are intentionally not emitted — the Operator ignores them.
 - **FM gRPC API** (IFA 005/006 §7.6) over Alertmanager.
 - **PM gRPC API** (§7.7) over Prometheus range queries — `PmJob` CRD, `Threshold`
   → generated `PrometheusRule`, and a Subscribe/Notify subsystem.
-- **Known gap:** SR-IOV VF traffic bypasses OVS and is invisible to KubeVirt, so
-  per-vNIC byte/packet counters for SR-IOV interfaces need a node-level VF
-  exporter (`kubevim_vnic_info` already carries `type` to identify them).
+- **SR-IOV VF counters:** VF traffic bypasses OVS and is invisible to KubeVirt, so
+  per-vNIC byte/packet counters come from a node-level VF exporter
+  (`sriov_vf_*`, keyed by `pciAddr`). `kubevim_vnic_info` now carries `pci_address`
+  + `host_id` to join those series to the ETSI compute/vNIC (see above); deploying
+  the exporter and the recording rules remains operator/NFVO-side work.

--- a/internal/kubevim/compute/kubevirt/manager.go
+++ b/internal/kubevim/compute/kubevirt/manager.go
@@ -2,8 +2,11 @@ package kubevirt
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
+
+	netattv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 
 	"github.com/google/uuid"
 	nfvcommon "github.com/kube-nfv/kube-vim-api/pkg/apis"
@@ -249,7 +252,7 @@ func (m *manager) AllocateComputeResource(ctx context.Context, req *vivnfm.Alloc
 	if err != nil {
 		return nil, fmt.Errorf("get VM instance '%s' (uid: %s): %w", vmName, vm.UID, err)
 	}
-	virtualCompute, err := nfvVirtualComputeFromKubevirtVm(ctx, m.networkManager, vm, vmi)
+	virtualCompute, err := nfvVirtualComputeFromKubevirtVm(ctx, m.networkManager, vm, vmi, m.getLauncherInfo(ctx, vmi))
 	if err != nil {
 		return nil, fmt.Errorf("convert kubevirt VM '%s' (uid: %s) to nfv VirtualCompute: %w", vmName, vm.UID, err)
 	}
@@ -270,13 +273,69 @@ func (m *manager) ListComputeResources(ctx context.Context) ([]*vivnfm.VirtualCo
 		if err != nil {
 			return nil, fmt.Errorf("get kubevirt VirtualMachineInstance '%s' (uid: %s): %w", vm.Name, vm.UID, err)
 		}
-		vComp, err := nfvVirtualComputeFromKubevirtVm(ctx, m.networkManager, &vm, vmi)
+		vComp, err := nfvVirtualComputeFromKubevirtVm(ctx, m.networkManager, &vm, vmi, m.getLauncherInfo(ctx, vmi))
 		if err != nil {
 			return nil, fmt.Errorf("convert kubevirt VM '%s' (uid: %s) to nfv VirtualCompute: %w", vm.Name, vm.UID, err)
 		}
 		res = append(res, vComp)
 	}
 	return res, nil
+}
+
+// kubevirtNetworkInfo mirrors the kubevirt.io/network-info annotation payload
+// (upstream type lives in the non-consumable kubevirt.io/kubevirt module).
+const kubevirtNetworkInfoAnnotation = "kubevirt.io/network-info"
+
+type kubevirtNetworkInfo struct {
+	Interfaces []struct {
+		Network    string               `json:"network"`
+		DeviceInfo *netattv1.DeviceInfo `json:"deviceInfo,omitempty"`
+	} `json:"interfaces,omitempty"`
+}
+
+type launcherInfo struct {
+	podName       string
+	hostPciByVnic map[string]string // vNIC name -> host PCI address (SR-IOV / pass-through)
+}
+
+// getLauncherInfo reads the VMI's virt-launcher pod name and per-vNIC host PCI
+// addresses. Best-effort: returns zero values on any error, never fails the caller.
+func (m *manager) getLauncherInfo(ctx context.Context, vmi *kubevirtv1.VirtualMachineInstance) launcherInfo {
+	info := launcherInfo{hostPciByVnic: map[string]string{}}
+	if vmi == nil || vmi.UID == "" {
+		return info
+	}
+	pods, err := m.k8sClient.CoreV1().Pods(*m.cfg.Namespace).List(ctx, v1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", kubevirtv1.CreatedByLabel, string(vmi.UID)),
+	})
+	if err != nil || len(pods.Items) == 0 {
+		return info
+	}
+	// Prefer the pod on the VMI's current node (unambiguous during migration).
+	pod := &pods.Items[0]
+	for i := range pods.Items {
+		if pods.Items[i].Spec.NodeName == vmi.Status.NodeName {
+			pod = &pods.Items[i]
+			break
+		}
+	}
+	info.podName = pod.Name
+
+	infoJSON, ok := pod.Annotations[kubevirtNetworkInfoAnnotation]
+	if !ok {
+		return info
+	}
+	var netInfo kubevirtNetworkInfo
+	if err := json.Unmarshal([]byte(infoJSON), &netInfo); err != nil {
+		return info
+	}
+	for _, iface := range netInfo.Interfaces {
+		if iface.DeviceInfo == nil || iface.DeviceInfo.Pci == nil || iface.DeviceInfo.Pci.PciAddress == "" {
+			continue
+		}
+		info.hostPciByVnic[iface.Network] = iface.DeviceInfo.Pci.PciAddress
+	}
+	return info
 }
 
 func (m *manager) GetComputeResource(ctx context.Context, opts ...compute.GetComputeOpt) (*vivnfm.VirtualCompute, error) {
@@ -291,7 +350,7 @@ func (m *manager) GetComputeResource(ctx context.Context, opts ...compute.GetCom
 		if err != nil {
 			return nil, fmt.Errorf("get kubevirt VirtualMachineInstance '%s' (uid: %s): %w", cfg.Name, vm.UID, err)
 		}
-		vComp, err := nfvVirtualComputeFromKubevirtVm(ctx, m.networkManager, vm, vmi)
+		vComp, err := nfvVirtualComputeFromKubevirtVm(ctx, m.networkManager, vm, vmi, m.getLauncherInfo(ctx, vmi))
 		if err != nil {
 			return nil, fmt.Errorf("convert kubevirt VM '%s' (uid: %s) to nfv VirtualCompute: %w", cfg.Name, vm.UID, err)
 		}
@@ -311,7 +370,7 @@ func (m *manager) GetComputeResource(ctx context.Context, opts ...compute.GetCom
 			if err != nil {
 				return nil, fmt.Errorf("get kubevirt VirtualMachineInstance '%s' (uid: %s): %w", vm.Name, vm.UID, err)
 			}
-			vComp, err := nfvVirtualComputeFromKubevirtVm(ctx, m.networkManager, &vm, vmi)
+			vComp, err := nfvVirtualComputeFromKubevirtVm(ctx, m.networkManager, &vm, vmi, m.getLauncherInfo(ctx, vmi))
 			if err != nil {
 				return nil, fmt.Errorf("convert kubevirt VM '%s' (uid: %s) to nfv VirtualCompute: %w", vm.Name, vm.UID, err)
 			}

--- a/internal/kubevim/compute/kubevirt/utils.go
+++ b/internal/kubevim/compute/kubevirt/utils.go
@@ -9,6 +9,7 @@ import (
 	nfvcommon "github.com/kube-nfv/kube-vim-api/pkg/apis"
 	vivnfm "github.com/kube-nfv/kube-vim-api/pkg/apis/vivnfm"
 	apperrors "github.com/kube-nfv/kube-vim/internal/errors"
+	"github.com/kube-nfv/kube-vim/internal/kubevim/compute"
 	"github.com/kube-nfv/kube-vim/internal/kubevim/flavour"
 	"github.com/kube-nfv/kube-vim/internal/kubevim/image"
 	"github.com/kube-nfv/kube-vim/internal/kubevim/network"
@@ -17,7 +18,7 @@ import (
 	kubevirtv1 "kubevirt.io/api/core/v1"
 )
 
-func nfvVirtualComputeFromKubevirtVm(ctx context.Context, netMgr network.Manager, vm *kubevirtv1.VirtualMachine, vmi *kubevirtv1.VirtualMachineInstance) (*vivnfm.VirtualCompute, error) {
+func nfvVirtualComputeFromKubevirtVm(ctx context.Context, netMgr network.Manager, vm *kubevirtv1.VirtualMachine, vmi *kubevirtv1.VirtualMachineInstance, launcher launcherInfo) (*vivnfm.VirtualCompute, error) {
 	if vmi == nil || vm == nil {
 		return nil, &apperrors.ErrInvalidArgument{Field: "kubevirt resources", Reason: "virtualMachine and virtualMachineInstance cannot be nil"}
 	}
@@ -44,6 +45,9 @@ func nfvVirtualComputeFromKubevirtVm(ctx context.Context, netMgr network.Manager
 	mdFields[KubevirtVmiStatusPhase] = string(vmi.Status.Phase)
 	if vmi.Status.Reason != "" {
 		mdFields[KubevirtVmiStatusReason] = vmi.Status.Reason
+	}
+	if launcher.podName != "" {
+		mdFields[compute.ComputePodNameMetadataKey] = launcher.podName
 	}
 
 	netIfaces := make([]*vivnfm.VirtualNetworkInterface, 0, len(vmi.Status.Interfaces))
@@ -124,6 +128,10 @@ func nfvVirtualComputeFromKubevirtVm(ctx context.Context, netMgr network.Manager
 				Mac: "initializing",
 			}
 			netMdFields[KubevirtInterfaceReady] = "false"
+		}
+
+		if pci, ok := launcher.hostPciByVnic[name]; ok && pci != "" {
+			netMdFields[compute.VnicHostPciAddressMetadataKey] = pci
 		}
 
 		netIfRes.Metadata = &nfvcommon.Metadata{

--- a/internal/kubevim/compute/manager.go
+++ b/internal/kubevim/compute/manager.go
@@ -16,6 +16,15 @@ const (
 	//    manual - SubnetID should be specified (default)
 	KubenfvVmNetworkSubnetAssignmentAnnotation = "compute.kubevim.kubenfv.io/network.subnet.assignment"
 	UnknownNetworkSubnetAssigmentAnnotationMsg = "unknown network subnet assignment annotation, should be one of: random, manual"
+
+	// VnicHostPciAddressMetadataKey holds the host PCI address backing a vNIC, set
+	// only when it maps to a host PCI device (SR-IOV VF or PCI pass-through). Absent
+	// for virtio/bridge vNICs, which are tap devices with no host PCI device.
+	VnicHostPciAddressMetadataKey = "compute.kubevim.kubenfv.io/host-pci-address"
+
+	// ComputePodNameMetadataKey holds the virt-launcher pod name backing a compute;
+	// the join key to pod-scoped backend series (cAdvisor, kube-state-metrics).
+	ComputePodNameMetadataKey = "compute.kubevim.kubenfv.io/pod-name"
 )
 
 type Manager interface {

--- a/internal/kubevim/telemetry/info.go
+++ b/internal/kubevim/telemetry/info.go
@@ -84,6 +84,8 @@ func observeComputeInfo(ctx context.Context, obs metric.Observer, logger *zap.Lo
 			attribute.String("flavour_id", c.GetFlavourId().GetValue()),
 			attribute.String("image_id", c.GetVcImageId().GetValue()),
 			attribute.String("host_id", c.GetHostId().GetValue()),
+			// pod_name is the virt-launcher pod, the join key to cAdvisor/kube-state-metrics.
+			attribute.String("pod_name", c.GetMetadata().GetFields()[compute.ComputePodNameMetadataKey]),
 			attribute.String("operational_state", c.GetOperationalState().String()),
 			attribute.String("running_state", c.GetRunningState().String()),
 		))
@@ -96,6 +98,12 @@ func observeComputeInfo(ctx context.Context, obs metric.Observer, logger *zap.Lo
 				attribute.String("subnet_id", nic.GetSubnetId().GetValue()),
 				attribute.String("network_port_id", nic.GetNetworkPortId().GetValue()),
 				attribute.String("type", nic.GetTypeVirtualNic().String()),
+				// host_id disambiguates the pci_address join across nodes (PCI addresses
+				// are node-local, not cluster-unique).
+				attribute.String("host_id", c.GetHostId().GetValue()),
+				// pci_address is the host VF/pass-through address for host-PCI vNICs
+				// (SR-IOV); empty for virtio/bridge vNICs.
+				attribute.String("pci_address", nic.GetMetadata().GetFields()[compute.VnicHostPciAddressMetadataKey]),
 			))
 		}
 	}


### PR DESCRIPTION
Closes #25.

Makes `kubevim_vnic_info` a deterministically-joinable index of a compute's vNICs so a Prometheus-based collector can attribute backend counters to a specific ETSI vNIC — for SR-IOV and bridge alike — and adds a pod-level join key on `kubevim_compute_info`.

## Changes

New labels on the correlation gauges:

- `kubevim_vnic_info.pci_address` — host VF/pass-through PCI address for host-PCI vNICs (SR-IOV); empty for virtio/bridge. Join key to the node-level SR-IOV VF exporter (`sriov_vf_*{pciAddr}`).
- `kubevim_vnic_info.host_id` — node name; keeps the `pci_address` join unambiguous (PCI addresses are node-local).
- `kubevim_compute_info.pod_name` — the virt-launcher pod; join key to cAdvisor (`container_*`) and kube-state-metrics (`kube_pod_*`), which `kubevirt_vmi_*` does not cover.

Both facts come from one best-effort read of the VMI's virt-launcher pod (`getLauncherInfo`): pod name + the `kubevirt.io/network-info` annotation (keyed by vNIC name → host PCI, no prefix stripping). On any error the labels are empty and the scrape still succeeds. The KubeVirt `network-info` payload type is mirrored locally — the upstream type lives in the non-consumable `kubevirt.io/kubevirt` application module.

No API change: per ETSI GS NFV-IFA 005/006 the PCI address is not a first-class `VirtualNetworkInterface` attribute, so it rides in the interface `metadata`.

RBAC: the compute-manager Role gains `pods` get/list (chart + raw manifest).

Bridge/virtio vNICs need no extra label — KubeVirt's `kubevirt_vmi_network_*.interface` equals `vnic_id`, so that join keys on the existing label.

## Verification (lab cluster)

All three joins resolve against live Prometheus:

- SR-IOV: `sriov_vf_rx_packets * on(pciAddr) …` → both VFs carry `compute_id`/`vnic_id` (`0000:b3:01.3`, `0000:b3:03.7`).
- Bridge: `kubevirt_vmi_network_receive_packets_total * on(name, interface) …` via `vnic_id` → `default`, `osm-mgmt-subnet-0-…` attributed.
- Pod: `container_cpu_usage_seconds_total * on(pod) …` via `pod_name` → resolves virt-launcher CPU to `compute_id`.
