### PR TITLE
Add unit tests for pure conversion/util logic

### DIFF
--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -10,7 +10,8 @@ Three GitHub Actions workflows drive validation and releases, all delegating to
 the `make` targets so CI mirrors local development:
 
 - **`ci`** — runs on every PR and push to `main`: `build` (+ generated/formatted
-  code is committed), `test`, and `helm-lint`. A no-op `ci` gate job aggregates
+  code is committed), `test` (`make test`; unit-test conventions in
+  [`testing.md`](testing.md)), and `helm-lint`. A no-op `ci` gate job aggregates
   them and is the single required status check on `main`.
 - **`release`** — runs on a `v*` tag: builds and pushes both images to
   `ghcr.io/kube-nfv`, then cuts a GitHub Release with binaries.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -47,7 +47,7 @@ with no Kubernetes client dependency:
 
 - `nfv⇄k8s` conversions and validation in each domain's `utils.go`
   (`network/kubeovn`, `network/sriov`, `flavour/kubevirt`, `compute/kubevirt`),
-- format/marshal helpers (CNI config rendering, quantity marshaling),
+- format/marshal helpers (e.g. SR-IOV CNI config rendering),
 - error → gRPC/k8s mapping (`internal/errors`).
 
 These functions survive an internals refactor, so the tests are durable.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,91 @@
+# Unit Testing
+
+Status: accepted (2026-07-31)
+Owner: kube-vim
+Scope: unit-test framework, mocking strategy, what is and isn't tested
+
+## TL;DR
+
+Unit tests use the Go stdlib `testing` package with table-driven subtests and
+[`testify`](https://github.com/stretchr/testify) (`require`/`assert`) for
+assertions. They run via `make test` (`go test -count=1 ./...`), which the CI
+`test` job invokes on every PR.
+
+Today tests cover **pure, client-free logic only** — the `nfv⇄k8s` conversion
+helpers in each domain's `utils.go`, format/marshal functions, and error
+mapping. Domain managers (which call Kubernetes clientsets) are deliberately
+left untested until the planned move to controller-runtime clients makes them
+cleanly mockable.
+
+## Problem
+
+The repo had almost no test coverage. We needed a testing approach that:
+
+- matches how the code is actually structured (plain client-go clientsets, not
+  controller-runtime reconcilers), and
+- doesn't create throwaway scaffolding, given a planned migration to
+  controller-runtime with cached clients.
+
+## Decisions
+
+### stdlib `testing` + testify, not Ginkgo/Gomega/envtest
+
+The heavyweight Kubernetes controller test stack (envtest spinning up a real
+apiserver, Ginkgo/Gomega BDD) exists for **controller-runtime reconcilers**.
+kube-vim is not one — it is a stateless gRPC service over plain client-go
+clientsets. Adopting that stack would be a mismatch, so tests use the Go
+standard `testing` package with table-driven subtests, plus `testify` for terse
+`require` (fatal preconditions) / `assert` (soft checks) assertions.
+
+Tests are **white-box** (same package as the code under test, `<file>_test.go`
+beside it) so unexported converters can be exercised directly.
+
+### Scope today: pure functions only
+
+The highest-value, lowest-cost, most stable surface is the deterministic logic
+with no Kubernetes client dependency:
+
+- `nfv⇄k8s` conversions and validation in each domain's `utils.go`
+  (`network/kubeovn`, `network/sriov`, `flavour/kubevirt`, `compute/kubevirt`),
+- format/marshal helpers (CNI config rendering, quantity marshaling),
+- error → gRPC/k8s mapping (`internal/errors`).
+
+These functions survive an internals refactor, so the tests are durable.
+
+### Managers are intentionally untested (for now)
+
+Domain managers hold **concrete `*Clientset` fields** built from `*rest.Config`
+inside their `NewXxx` constructors — they are not injectable, so a fake client
+cannot be substituted without a refactor.
+
+Rather than refactor every manager to an injectable clientset `Interface` now,
+we wait for the planned migration to **controller-runtime + cached clients** and
+then test managers against `sigs.k8s.io/controller-runtime/pkg/client/fake`.
+Building fake-clientset plumbing against the current concrete clients would be
+thrown away by that migration, so it is explicitly avoided.
+
+The most complex untested logic is the network/IPAM resolution in
+`compute/kubevirt/manager.go` (`initNetworks`, `getNetworkIpam`,
+`getSubnetIpam`) — flagged for care until it becomes testable.
+
+## How to add a test
+
+- Put it in `<file>_test.go` next to the code, `package <same>` (white-box).
+- Prefer a table-driven `t.Run` per case; use `require` for setup that must
+  succeed and `assert` for the actual expectations.
+- Constructing Kubernetes objects that must pass the ownership/instantiation
+  guards:
+  - `misc.IsObjectInstantiated` needs `UID`, `ResourceVersion`, and a non-zero
+    `CreationTimestamp`.
+  - `misc.IsObjectManagedByKubeNfv` needs the
+    `app.kubernetes.io/managed-by: kube-nfv` label.
+  - See `managedMeta(...)` in `internal/kubevim/network/kubeovn/utils_test.go`
+    for a reusable helper.
+- Run one package: `go test ./internal/kubevim/network/kubeovn/ -run TestName -v`.
+
+## Known gaps / follow-ups
+
+- **Managers, gateway wiring, and server adapters are untested** — pending the
+  controller-runtime migration for the manager layer.
+- **No coverage gate in CI.** `make test` runs but coverage is not measured or
+  enforced.

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/kube-nfv/query-filter v0.0.2-alpha1
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/viper v1.21.0
+	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.69.0
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/exporters/prometheus v0.66.0
@@ -94,6 +95,7 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.34.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.31.0 // indirect

--- a/internal/kubevim/compute/kubevirt/utils_test.go
+++ b/internal/kubevim/compute/kubevirt/utils_test.go
@@ -1,0 +1,171 @@
+package kubevirt
+
+import (
+	"testing"
+
+	nfvcommon "github.com/kube-nfv/kube-vim-api/pkg/apis"
+	"github.com/kube-nfv/kube-vim/internal/kubevim/flavour"
+	"github.com/kube-nfv/kube-vim/internal/kubevim/image"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+)
+
+func TestGetRunningState(t *testing.T) {
+	tests := []struct {
+		name string
+		vm   *kubevirtv1.VirtualMachine
+		vmi  *kubevirtv1.VirtualMachineInstance
+		want nfvcommon.ComputeRunningState
+	}{
+		{
+			name: "halted -> stopped",
+			vm:   &kubevirtv1.VirtualMachine{Status: kubevirtv1.VirtualMachineStatus{RunStrategy: kubevirtv1.RunStrategyHalted}},
+			vmi:  &kubevirtv1.VirtualMachineInstance{},
+			want: nfvcommon.ComputeRunningState_STOPPED,
+		},
+		{
+			name: "paused condition -> paused",
+			vm:   &kubevirtv1.VirtualMachine{},
+			vmi: &kubevirtv1.VirtualMachineInstance{Status: kubevirtv1.VirtualMachineInstanceStatus{
+				Conditions: []kubevirtv1.VirtualMachineInstanceCondition{{Type: kubevirtv1.VirtualMachineInstancePaused}},
+			}},
+			want: nfvcommon.ComputeRunningState_PAUSED,
+		},
+		{
+			name: "terminating",
+			vm:   &kubevirtv1.VirtualMachine{Status: kubevirtv1.VirtualMachineStatus{PrintableStatus: kubevirtv1.VirtualMachineStatusTerminating}},
+			vmi:  &kubevirtv1.VirtualMachineInstance{},
+			want: nfvcommon.ComputeRunningState_TERMINATING,
+		},
+		{
+			name: "running",
+			vm:   &kubevirtv1.VirtualMachine{Status: kubevirtv1.VirtualMachineStatus{Created: true, Ready: true}},
+			vmi:  &kubevirtv1.VirtualMachineInstance{Status: kubevirtv1.VirtualMachineInstanceStatus{Phase: kubevirtv1.Running}},
+			want: nfvcommon.ComputeRunningState_RUNNING,
+		},
+		{
+			name: "pending -> starting",
+			vm:   &kubevirtv1.VirtualMachine{},
+			vmi:  &kubevirtv1.VirtualMachineInstance{Status: kubevirtv1.VirtualMachineInstanceStatus{Phase: kubevirtv1.Pending}},
+			want: nfvcommon.ComputeRunningState_STARTING,
+		},
+		{
+			name: "failed",
+			vm:   &kubevirtv1.VirtualMachine{},
+			vmi:  &kubevirtv1.VirtualMachineInstance{Status: kubevirtv1.VirtualMachineInstanceStatus{Phase: kubevirtv1.Failed}},
+			want: nfvcommon.ComputeRunningState_FAILED,
+		},
+		{
+			name: "unknown",
+			vm:   &kubevirtv1.VirtualMachine{},
+			vmi:  &kubevirtv1.VirtualMachineInstance{},
+			want: nfvcommon.ComputeRunningState_UNKNOWN,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, getRunningState(tt.vm, tt.vmi))
+		})
+	}
+}
+
+func TestGetFlavourFromInstanceSpec(t *testing.T) {
+	t.Run("present", func(t *testing.T) {
+		vm := &kubevirtv1.VirtualMachine{ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{flavour.K8sFlavourIdLabel: "flav-1"},
+		}}
+		id, err := getFlavourFromInstanceSpec(vm)
+		require.NoError(t, err)
+		assert.Equal(t, "flav-1", id.GetValue())
+	})
+	t.Run("missing", func(t *testing.T) {
+		_, err := getFlavourFromInstanceSpec(&kubevirtv1.VirtualMachine{})
+		assert.Error(t, err)
+	})
+}
+
+func TestGetImageIdFromInstnceSpec(t *testing.T) {
+	t.Run("present", func(t *testing.T) {
+		vm := &kubevirtv1.VirtualMachine{ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{image.K8sImageIdLabel: "img-1"},
+		}}
+		id, err := getImageIdFromInstnceSpec(vm)
+		require.NoError(t, err)
+		assert.Equal(t, "img-1", id.GetValue())
+	})
+	t.Run("missing", func(t *testing.T) {
+		_, err := getImageIdFromInstnceSpec(&kubevirtv1.VirtualMachine{})
+		assert.Error(t, err)
+	})
+}
+
+func TestIfaceBindingMethodToNfv(t *testing.T) {
+	tests := []struct {
+		name    string
+		method  kubevirtv1.InterfaceBindingMethod
+		want    nfvcommon.TypeVirtualNic
+		wantErr bool
+	}{
+		{"bridge", kubevirtv1.InterfaceBindingMethod{Bridge: &kubevirtv1.InterfaceBridge{}}, nfvcommon.TypeVirtualNic_TYPE_VIRTUAL_NIC_BRIDGE, false},
+		{"masquerade", kubevirtv1.InterfaceBindingMethod{Masquerade: &kubevirtv1.InterfaceMasquerade{}}, nfvcommon.TypeVirtualNic_TYPE_VIRTUAL_NIC_BRIDGE, false},
+		{"sriov", kubevirtv1.InterfaceBindingMethod{SRIOV: &kubevirtv1.InterfaceSRIOV{}}, nfvcommon.TypeVirtualNic_TYPE_VIRTUAL_NIC_SRIOV, false},
+		{"unknown", kubevirtv1.InterfaceBindingMethod{}, nfvcommon.TypeVirtualNic_TYPE_VIRTUAL_NIC_BRIDGE, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ifaceBindingMethodToNfv(tt.method)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGetNetworkFromVm(t *testing.T) {
+	vm := &kubevirtv1.VirtualMachine{Spec: kubevirtv1.VirtualMachineSpec{
+		Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+			Spec: kubevirtv1.VirtualMachineInstanceSpec{
+				Networks: []kubevirtv1.Network{{Name: "net1"}},
+			},
+		},
+	}}
+	t.Run("found", func(t *testing.T) {
+		net, err := getNetworkFromVm("net1", vm)
+		require.NoError(t, err)
+		assert.Equal(t, "net1", net.Name)
+	})
+	t.Run("not found", func(t *testing.T) {
+		_, err := getNetworkFromVm("missing", vm)
+		assert.Error(t, err)
+	})
+	t.Run("nil template", func(t *testing.T) {
+		_, err := getNetworkFromVm("net1", &kubevirtv1.VirtualMachine{})
+		assert.Error(t, err)
+	})
+}
+
+func TestGetInterfaceFromVm(t *testing.T) {
+	vm := &kubevirtv1.VirtualMachine{Spec: kubevirtv1.VirtualMachineSpec{
+		Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+			Spec: kubevirtv1.VirtualMachineInstanceSpec{
+				Domain: kubevirtv1.DomainSpec{Devices: kubevirtv1.Devices{
+					Interfaces: []kubevirtv1.Interface{{Name: "iface1"}},
+				}},
+			},
+		},
+	}}
+	t.Run("found", func(t *testing.T) {
+		iface, err := getInterfaceFromVm("iface1", vm)
+		require.NoError(t, err)
+		assert.Equal(t, "iface1", iface.Name)
+	})
+	t.Run("not found", func(t *testing.T) {
+		_, err := getInterfaceFromVm("missing", vm)
+		assert.Error(t, err)
+	})
+}

--- a/internal/kubevim/flavour/kubevirt/utils_test.go
+++ b/internal/kubevim/flavour/kubevirt/utils_test.go
@@ -1,0 +1,101 @@
+package kubevirt
+
+import (
+	"testing"
+	"time"
+
+	vivnfm "github.com/kube-nfv/kube-vim-api/pkg/apis/vivnfm"
+	common "github.com/kube-nfv/kube-vim/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestFlavourNameIdRoundTrip(t *testing.T) {
+	name := flavourNameFromId("abc")
+	assert.Equal(t, "flavour-abc", name)
+	assert.Equal(t, "flavour-pref-abc", flavourPreferenceNameFromId("abc"))
+
+	id, err := idFromFlavourName(name)
+	require.NoError(t, err)
+	assert.Equal(t, "abc", id)
+}
+
+func TestIdFromFlavourNameErrors(t *testing.T) {
+	_, err := idFromFlavourName("badprefix-abc")
+	assert.Error(t, err)
+
+	_, err = idFromFlavourName("flavour-")
+	assert.Error(t, err)
+}
+
+func newNfvFlavour() *vivnfm.VirtualComputeFlavour {
+	mem := resource.MustParse("2Gi")
+	return &vivnfm.VirtualComputeFlavour{
+		VirtualCpu:    &vivnfm.VirtualCpuData{NumVirtualCpu: 4},
+		VirtualMemory: &vivnfm.VirtualMemoryData{VirtualMemSize: &mem},
+	}
+}
+
+func TestKubeVirtInstanceTypePreferencesFromNfvFlavour(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		instType, pref, err := kubeVirtInstanceTypePreferencesFromNfvFlavour("abc", newNfvFlavour())
+		require.NoError(t, err)
+		assert.Equal(t, "flavour-abc", instType.Name)
+		assert.Equal(t, "flavour-pref-abc", pref.Name)
+		assert.Equal(t, uint32(4), instType.Spec.CPU.Guest)
+		assert.Equal(t, "2Gi", instType.Spec.Memory.Guest.String())
+		assert.Equal(t, common.KubeNfvName, instType.Labels[common.K8sManagedByLabel])
+	})
+
+	errCases := map[string]*vivnfm.VirtualComputeFlavour{
+		"nil flavour": nil,
+		"nil cpu":     {VirtualMemory: &vivnfm.VirtualMemoryData{}},
+		"nil memory":  {VirtualCpu: &vivnfm.VirtualCpuData{NumVirtualCpu: 1}},
+		"zero cpu":    {VirtualCpu: &vivnfm.VirtualCpuData{NumVirtualCpu: 0}, VirtualMemory: &vivnfm.VirtualMemoryData{}},
+	}
+	for name, flavour := range errCases {
+		t.Run(name, func(t *testing.T) {
+			_, _, err := kubeVirtInstanceTypePreferencesFromNfvFlavour("abc", flavour)
+			assert.Error(t, err)
+		})
+	}
+}
+
+// TestFlavourRoundTrip converts an nfv flavour to kubevirt objects and back,
+// asserting the essential attributes survive the round trip.
+func TestFlavourRoundTrip(t *testing.T) {
+	instType, pref, err := kubeVirtInstanceTypePreferencesFromNfvFlavour("abc", newNfvFlavour())
+	require.NoError(t, err)
+
+	// nfvFlavourFromKubeVirtInstanceTypePreferences requires instantiated objects.
+	instantiate := func(m *metav1.ObjectMeta) {
+		m.UID = types.UID("uid-" + m.Name)
+		m.ResourceVersion = "1"
+		m.CreationTimestamp = metav1.NewTime(time.Now())
+	}
+	instantiate(&instType.ObjectMeta)
+	instantiate(&pref.ObjectMeta)
+
+	got, err := nfvFlavourFromKubeVirtInstanceTypePreferences("abc", instType, pref)
+	require.NoError(t, err)
+	assert.Equal(t, "abc", got.FlavourId.GetValue())
+	assert.Equal(t, uint32(4), got.VirtualCpu.NumVirtualCpu)
+	require.NotNil(t, got.VirtualMemory.VirtualMemSize)
+	assert.Equal(t, "2Gi", got.VirtualMemory.VirtualMemSize.String())
+}
+
+func TestNfvFlavourFromKubeVirtErrors(t *testing.T) {
+	t.Run("nil instancetype", func(t *testing.T) {
+		_, err := nfvFlavourFromKubeVirtInstanceTypePreferences("abc", nil, nil)
+		assert.Error(t, err)
+	})
+	t.Run("not instantiated", func(t *testing.T) {
+		instType, _, err := kubeVirtInstanceTypePreferencesFromNfvFlavour("abc", newNfvFlavour())
+		require.NoError(t, err)
+		_, err = nfvFlavourFromKubeVirtInstanceTypePreferences("abc", instType, nil)
+		assert.Error(t, err)
+	})
+}

--- a/internal/kubevim/network/kubeovn/utils_test.go
+++ b/internal/kubevim/network/kubeovn/utils_test.go
@@ -1,1 +1,254 @@
 package kubeovn
+
+import (
+	"testing"
+	"time"
+
+	kubeovnv1 "github.com/kube-nfv/kube-vim-api/kube-ovn-api/pkg/apis/kubeovn/v1"
+	nfvcommon "github.com/kube-nfv/kube-vim-api/pkg/apis"
+	vivnfm "github.com/kube-nfv/kube-vim-api/pkg/apis/vivnfm"
+	common "github.com/kube-nfv/kube-vim/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// managedMeta returns an ObjectMeta that passes both IsObjectInstantiated and
+// IsObjectManagedByKubeNfv checks.
+func managedMeta(name string) metav1.ObjectMeta {
+	return metav1.ObjectMeta{
+		Name:              name,
+		UID:               types.UID("uid-" + name),
+		ResourceVersion:   "1",
+		CreationTimestamp: metav1.NewTime(time.Now()),
+		Labels:            map[string]string{common.K8sManagedByLabel: common.KubeNfvName},
+	}
+}
+
+func TestKubeovnVpcFromNfvNetworkData(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		vpc, err := kubeovnVpcFromNfvNetworkData("net1", &vivnfm.VirtualNetworkData{})
+		require.NoError(t, err)
+		assert.Equal(t, "net1", vpc.Name)
+		assert.Equal(t, common.KubeNfvName, vpc.Labels[common.K8sManagedByLabel])
+	})
+	t.Run("empty name", func(t *testing.T) {
+		_, err := kubeovnVpcFromNfvNetworkData("", &vivnfm.VirtualNetworkData{})
+		assert.Error(t, err)
+	})
+	t.Run("nil data", func(t *testing.T) {
+		_, err := kubeovnVpcFromNfvNetworkData("net1", nil)
+		assert.Error(t, err)
+	})
+}
+
+func TestKubeovnVpcToNfvNetwork(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		vpc := &kubeovnv1.Vpc{ObjectMeta: managedMeta("net1")}
+		subnets := []*nfvcommon.Identifier{{Value: "sub1"}}
+		got, err := kubeovnVpcToNfvNetwork(vpc, subnets)
+		require.NoError(t, err)
+		assert.Equal(t, "uid-net1", got.NetworkResourceId.GetValue())
+		assert.Equal(t, "net1", got.GetNetworkResourceName())
+		assert.Equal(t, nfvcommon.NetworkType_NETWORK_TYPE_OVERLAY, got.NetworkType)
+		assert.Equal(t, subnets, got.SubnetId)
+	})
+	t.Run("nil vpc", func(t *testing.T) {
+		_, err := kubeovnVpcToNfvNetwork(nil, nil)
+		assert.Error(t, err)
+	})
+	t.Run("not instantiated", func(t *testing.T) {
+		vpc := &kubeovnv1.Vpc{ObjectMeta: metav1.ObjectMeta{
+			Name:   "net1",
+			UID:    "uid-1",
+			Labels: map[string]string{common.K8sManagedByLabel: common.KubeNfvName},
+		}}
+		_, err := kubeovnVpcToNfvNetwork(vpc, nil)
+		assert.Error(t, err)
+	})
+	t.Run("not managed", func(t *testing.T) {
+		vpc := &kubeovnv1.Vpc{ObjectMeta: metav1.ObjectMeta{
+			Name:              "net1",
+			UID:               "uid-1",
+			ResourceVersion:   "1",
+			CreationTimestamp: metav1.NewTime(time.Now()),
+		}}
+		_, err := kubeovnVpcToNfvNetwork(vpc, nil)
+		assert.Error(t, err)
+	})
+}
+
+func TestKubeovnVlanToNfvNetwork(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		vlan := &kubeovnv1.Vlan{
+			ObjectMeta: managedMeta("vlan1"),
+			Spec:       kubeovnv1.VlanSpec{ID: 100, Provider: "provider1"},
+		}
+		got, err := kubeovnVlanToNfvNetwork(vlan, nil)
+		require.NoError(t, err)
+		assert.Equal(t, nfvcommon.NetworkType_NETWORK_TYPE_UNDERLAY, got.NetworkType)
+		assert.Equal(t, "provider1", got.GetProviderNetwork())
+		assert.Equal(t, uint64(100), got.GetSegmentationId())
+	})
+	t.Run("nil vlan", func(t *testing.T) {
+		_, err := kubeovnVlanToNfvNetwork(nil, nil)
+		assert.Error(t, err)
+	})
+}
+
+func TestKubeovnVlanFromNfvNetworkData(t *testing.T) {
+	provider := "provider1"
+	segID := uint64(100)
+	underlay := nfvcommon.NetworkType_NETWORK_TYPE_UNDERLAY
+	t.Run("valid", func(t *testing.T) {
+		vlan, err := kubeovnVlanFromNfvNetworkData("vlan1", &vivnfm.VirtualNetworkData{
+			NetworkType:     &underlay,
+			ProviderNetwork: &provider,
+			SegmentationId:  &segID,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 100, vlan.Spec.ID)
+		assert.Equal(t, "provider1", vlan.Spec.Provider)
+	})
+	t.Run("wrong network type", func(t *testing.T) {
+		overlay := nfvcommon.NetworkType_NETWORK_TYPE_OVERLAY
+		_, err := kubeovnVlanFromNfvNetworkData("vlan1", &vivnfm.VirtualNetworkData{
+			NetworkType:     &overlay,
+			ProviderNetwork: &provider,
+		})
+		assert.Error(t, err)
+	})
+	t.Run("missing provider", func(t *testing.T) {
+		_, err := kubeovnVlanFromNfvNetworkData("vlan1", &vivnfm.VirtualNetworkData{NetworkType: &underlay})
+		assert.Error(t, err)
+	})
+	t.Run("empty name", func(t *testing.T) {
+		_, err := kubeovnVlanFromNfvNetworkData("", &vivnfm.VirtualNetworkData{NetworkType: &underlay, ProviderNetwork: &provider})
+		assert.Error(t, err)
+	})
+}
+
+func TestKubeovnIpVersionRoundTrip(t *testing.T) {
+	v4 := nfvcommon.IPVersion_IPV4
+	v6 := nfvcommon.IPVersion_IPV6
+	tests := []struct {
+		nfv *nfvcommon.IPVersion
+		str string
+	}{
+		{&v4, "IPv4"},
+		{&v6, "IPv6"},
+	}
+	for _, tt := range tests {
+		s, err := kubeovnIpVersionFromNfv(tt.nfv)
+		require.NoError(t, err)
+		assert.Equal(t, tt.str, s)
+
+		back, err := nfvIpversionFromKubeovn(s)
+		require.NoError(t, err)
+		assert.Equal(t, *tt.nfv, *back)
+	}
+}
+
+func TestKubeovnIpVersionErrors(t *testing.T) {
+	_, err := kubeovnIpVersionFromNfv(nil)
+	assert.Error(t, err)
+
+	unknown := nfvcommon.IPVersion(99)
+	_, err = kubeovnIpVersionFromNfv(&unknown)
+	assert.Error(t, err)
+
+	_, err = nfvIpversionFromKubeovn("")
+	assert.Error(t, err)
+
+	_, err = nfvIpversionFromKubeovn("Dual")
+	assert.Error(t, err)
+}
+
+func TestKubeovnSubnetFromNfvSubnetData(t *testing.T) {
+	v4 := nfvcommon.IPVersion_IPV4
+	t.Run("valid with defaults", func(t *testing.T) {
+		sub, err := kubeovnSubnetFromNfvSubnetData("sub1", &vivnfm.NetworkSubnetData{
+			IpVersion: &v4,
+			Cidr:      &nfvcommon.IPSubnetCIDR{Cidr: "10.0.0.0/24"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "IPv4", sub.Spec.Protocol)
+		assert.Equal(t, "10.0.0.0/24", sub.Spec.CIDRBlock)
+		assert.True(t, sub.Spec.EnableDHCP, "dhcp defaults to enabled when unset")
+		assert.Empty(t, sub.Spec.Gateway)
+	})
+	t.Run("dhcp disabled and gateway", func(t *testing.T) {
+		dhcp := false
+		sub, err := kubeovnSubnetFromNfvSubnetData("sub1", &vivnfm.NetworkSubnetData{
+			IpVersion:     &v4,
+			Cidr:          &nfvcommon.IPSubnetCIDR{Cidr: "10.0.0.0/24"},
+			IsDhcpEnabled: &dhcp,
+			GatewayIp:     &nfvcommon.IPAddress{Ip: "10.0.0.1"},
+		})
+		require.NoError(t, err)
+		assert.False(t, sub.Spec.EnableDHCP)
+		assert.Equal(t, "10.0.0.1", sub.Spec.Gateway)
+	})
+	t.Run("invalid cidr", func(t *testing.T) {
+		_, err := kubeovnSubnetFromNfvSubnetData("sub1", &vivnfm.NetworkSubnetData{
+			IpVersion: &v4,
+			Cidr:      &nfvcommon.IPSubnetCIDR{Cidr: "bad"},
+		})
+		assert.Error(t, err)
+	})
+	t.Run("missing cidr", func(t *testing.T) {
+		_, err := kubeovnSubnetFromNfvSubnetData("sub1", &vivnfm.NetworkSubnetData{IpVersion: &v4})
+		assert.Error(t, err)
+	})
+	t.Run("invalid gateway", func(t *testing.T) {
+		_, err := kubeovnSubnetFromNfvSubnetData("sub1", &vivnfm.NetworkSubnetData{
+			IpVersion: &v4,
+			Cidr:      &nfvcommon.IPSubnetCIDR{Cidr: "10.0.0.0/24"},
+			GatewayIp: &nfvcommon.IPAddress{Ip: "bad"},
+		})
+		assert.Error(t, err)
+	})
+}
+
+func TestNfvNetworkSubnetFromKubeovnSubnet(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		sub := &kubeovnv1.Subnet{
+			ObjectMeta: managedMeta("sub1"),
+			Spec: kubeovnv1.SubnetSpec{
+				Protocol:   "IPv4",
+				CIDRBlock:  "10.0.0.0/24",
+				Gateway:    "10.0.0.1",
+				EnableDHCP: true,
+			},
+		}
+		got, err := nfvNetworkSubnetFromKubeovnSubnet(sub)
+		require.NoError(t, err)
+		assert.Equal(t, nfvcommon.IPVersion_IPV4, got.IpVersion)
+		assert.Equal(t, "10.0.0.0/24", got.Cidr.GetCidr())
+		assert.Equal(t, "10.0.0.1", got.GatewayIp.GetIp())
+		assert.True(t, got.IsDhcpEnabled)
+	})
+	t.Run("nil", func(t *testing.T) {
+		_, err := nfvNetworkSubnetFromKubeovnSubnet(nil)
+		assert.Error(t, err)
+	})
+	t.Run("not managed", func(t *testing.T) {
+		sub := &kubeovnv1.Subnet{ObjectMeta: metav1.ObjectMeta{
+			Name:              "sub1",
+			UID:               "uid-1",
+			ResourceVersion:   "1",
+			CreationTimestamp: metav1.NewTime(time.Now()),
+		}}
+		_, err := nfvNetworkSubnetFromKubeovnSubnet(sub)
+		assert.Error(t, err)
+	})
+}
+
+func TestFormatHelpers(t *testing.T) {
+	assert.Equal(t, "net1-subnet-sub1", formatSubnetName("net1", "sub1"))
+	assert.Equal(t, "sub1-netattach", formatNetAttachName("sub1"))
+	assert.Equal(t, "na1.ns1.ovn", formatNetAttachKubeOvnProvider("na1", "ns1"))
+	assert.Contains(t, formatNetAttachConfig("na1", "ns1"), `"provider": "na1.ns1.ovn"`)
+	assert.Contains(t, formatNetAttachConfig("na1", "ns1"), `"type": "kube-ovn"`)
+}

--- a/internal/kubevim/network/sriov/utils_test.go
+++ b/internal/kubevim/network/sriov/utils_test.go
@@ -1,0 +1,81 @@
+package sriov
+
+import (
+	"encoding/json"
+	"testing"
+
+	netattv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	nfvcommon "github.com/kube-nfv/kube-vim-api/pkg/apis"
+	common "github.com/kube-nfv/kube-vim/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestFormatOvsCniConfig(t *testing.T) {
+	t.Run("with vlan", func(t *testing.T) {
+		out, err := formatOvsCniConfig("net1", 100, "/run/ovn.sock")
+		require.NoError(t, err)
+		var cfg ovsCniConfig
+		require.NoError(t, json.Unmarshal([]byte(out), &cfg))
+		assert.Equal(t, sriovCniVersion, cfg.CniVersion)
+		assert.Equal(t, "net1", cfg.Name)
+		assert.Equal(t, "ovs", cfg.Type)
+		require.NotNil(t, cfg.Vlan)
+		assert.Equal(t, 100, *cfg.Vlan)
+		assert.Equal(t, "/run/ovn.sock", cfg.SocketFile)
+	})
+	t.Run("vlan zero omitted", func(t *testing.T) {
+		out, err := formatOvsCniConfig("net1", 0, "/run/ovn.sock")
+		require.NoError(t, err)
+		assert.NotContains(t, out, "vlan")
+		var cfg ovsCniConfig
+		require.NoError(t, json.Unmarshal([]byte(out), &cfg))
+		assert.Nil(t, cfg.Vlan)
+	})
+}
+
+func TestNadToNfvNetwork(t *testing.T) {
+	config, err := formatOvsCniConfig("net1", 100, "/run/ovn.sock")
+	require.NoError(t, err)
+
+	newNad := func(managed bool) *netattv1.NetworkAttachmentDefinition {
+		labels := map[string]string{}
+		if managed {
+			labels[common.K8sManagedByLabel] = common.KubeNfvName
+		}
+		return &netattv1.NetworkAttachmentDefinition{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "net1",
+				UID:         "uid-1",
+				Labels:      labels,
+				Annotations: map[string]string{nadResourceNameAnnotation: "intel.com/sriov"},
+			},
+			Spec: netattv1.NetworkAttachmentDefinitionSpec{Config: config},
+		}
+	}
+
+	t.Run("valid", func(t *testing.T) {
+		got, err := nadToNfvNetwork(newNad(true))
+		require.NoError(t, err)
+		assert.Equal(t, nfvcommon.NetworkType_NETWORK_TYPE_SRIOV, got.NetworkType)
+		assert.Equal(t, "net1", got.GetNetworkResourceName())
+		assert.Equal(t, "intel.com/sriov", got.GetProviderNetwork())
+		assert.Equal(t, uint64(100), got.GetSegmentationId())
+		assert.Equal(t, "uid-1", got.NetworkResourceId.GetValue())
+	})
+	t.Run("nil", func(t *testing.T) {
+		_, err := nadToNfvNetwork(nil)
+		assert.Error(t, err)
+	})
+	t.Run("no uid", func(t *testing.T) {
+		nad := newNad(true)
+		nad.UID = ""
+		_, err := nadToNfvNetwork(nad)
+		assert.Error(t, err)
+	})
+	t.Run("not managed", func(t *testing.T) {
+		_, err := nadToNfvNetwork(newNad(false))
+		assert.Error(t, err)
+	})
+}

--- a/internal/kubevim/network/utils_test.go
+++ b/internal/kubevim/network/utils_test.go
@@ -1,0 +1,31 @@
+package network
+
+import (
+	"testing"
+
+	nfvcommon "github.com/kube-nfv/kube-vim-api/pkg/apis"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIpBelongsToCidr(t *testing.T) {
+	tests := []struct {
+		name string
+		ip   *nfvcommon.IPAddress
+		cidr *nfvcommon.IPSubnetCIDR
+		want bool
+	}{
+		{"ipv4 inside", &nfvcommon.IPAddress{Ip: "10.0.0.5"}, &nfvcommon.IPSubnetCIDR{Cidr: "10.0.0.0/24"}, true},
+		{"ipv4 outside", &nfvcommon.IPAddress{Ip: "10.0.1.5"}, &nfvcommon.IPSubnetCIDR{Cidr: "10.0.0.0/24"}, false},
+		{"ipv4 network address", &nfvcommon.IPAddress{Ip: "10.0.0.0"}, &nfvcommon.IPSubnetCIDR{Cidr: "10.0.0.0/24"}, true},
+		{"ipv6 inside", &nfvcommon.IPAddress{Ip: "2001:db8::1"}, &nfvcommon.IPSubnetCIDR{Cidr: "2001:db8::/32"}, true},
+		{"nil ip", nil, &nfvcommon.IPSubnetCIDR{Cidr: "10.0.0.0/24"}, false},
+		{"nil cidr", &nfvcommon.IPAddress{Ip: "10.0.0.5"}, nil, false},
+		{"invalid ip", &nfvcommon.IPAddress{Ip: "not-an-ip"}, &nfvcommon.IPSubnetCIDR{Cidr: "10.0.0.0/24"}, false},
+		{"invalid cidr", &nfvcommon.IPAddress{Ip: "10.0.0.5"}, &nfvcommon.IPSubnetCIDR{Cidr: "not-a-cidr"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IpBelongsToCidr(tt.ip, tt.cidr))
+		})
+	}
+}

--- a/internal/misc/utils_test.go
+++ b/internal/misc/utils_test.go
@@ -1,0 +1,102 @@
+package misc
+
+import (
+	"testing"
+	"time"
+
+	common "github.com/kube-nfv/kube-vim/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestIsUUID(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"valid uuid", "550e8400-e29b-41d4-a716-446655440000", true},
+		{"valid uuid uppercase", "550E8400-E29B-41D4-A716-446655440000", true},
+		{"not a uuid", "not-a-uuid", false},
+		{"empty", "", false},
+		{"truncated", "550e8400-e29b-41d4-a716", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsUUID(tt.input))
+		})
+	}
+}
+
+func TestMergeLabels(t *testing.T) {
+	t.Run("adds missing key", func(t *testing.T) {
+		changed, merged := MergeLabels(map[string]string{"a": "1"}, map[string]string{"b": "2"})
+		assert.True(t, changed)
+		assert.Equal(t, map[string]string{"a": "1", "b": "2"}, merged)
+	})
+	t.Run("overwrites different value", func(t *testing.T) {
+		changed, merged := MergeLabels(map[string]string{"a": "1"}, map[string]string{"a": "2"})
+		assert.True(t, changed)
+		assert.Equal(t, "2", merged["a"])
+	})
+	t.Run("no change when required already present", func(t *testing.T) {
+		changed, merged := MergeLabels(map[string]string{"a": "1", "b": "2"}, map[string]string{"a": "1"})
+		assert.False(t, changed)
+		assert.Equal(t, map[string]string{"a": "1", "b": "2"}, merged)
+	})
+	t.Run("does not mutate current", func(t *testing.T) {
+		current := map[string]string{"a": "1"}
+		_, merged := MergeLabels(current, map[string]string{"b": "2"})
+		assert.Equal(t, map[string]string{"a": "1"}, current)
+		assert.NotSame(t, &current, &merged)
+	})
+}
+
+func TestUIDIdentifierRoundTrip(t *testing.T) {
+	uid := types.UID("abc-123")
+	id := UIDToIdentifier(uid)
+	require.NotNil(t, id)
+	assert.Equal(t, "abc-123", id.Value)
+	assert.Equal(t, uid, IdentifierToUID(id))
+}
+
+func TestIsObjectInstantiated(t *testing.T) {
+	instantiated := metav1.ObjectMeta{
+		UID:               "uid-1",
+		ResourceVersion:   "42",
+		CreationTimestamp: metav1.NewTime(time.Now()),
+	}
+	tests := []struct {
+		name string
+		obj  metav1.ObjectMeta
+		want bool
+	}{
+		{"fully instantiated", instantiated, true},
+		{"missing uid", metav1.ObjectMeta{ResourceVersion: "42", CreationTimestamp: metav1.NewTime(time.Now())}, false},
+		{"missing resource version", metav1.ObjectMeta{UID: "uid-1", CreationTimestamp: metav1.NewTime(time.Now())}, false},
+		{"zero creation timestamp", metav1.ObjectMeta{UID: "uid-1", ResourceVersion: "42"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obj := tt.obj
+			assert.Equal(t, tt.want, IsObjectInstantiated(&obj))
+		})
+	}
+}
+
+func TestIsObjectManagedByKubeNfv(t *testing.T) {
+	t.Run("managed", func(t *testing.T) {
+		obj := metav1.ObjectMeta{Labels: map[string]string{common.K8sManagedByLabel: common.KubeNfvName}}
+		assert.True(t, IsObjectManagedByKubeNfv(&obj))
+	})
+	t.Run("different manager", func(t *testing.T) {
+		obj := metav1.ObjectMeta{Labels: map[string]string{common.K8sManagedByLabel: "someone-else"}}
+		assert.False(t, IsObjectManagedByKubeNfv(&obj))
+	})
+	t.Run("no labels", func(t *testing.T) {
+		obj := metav1.ObjectMeta{}
+		assert.False(t, IsObjectManagedByKubeNfv(&obj))
+	})
+}


### PR DESCRIPTION
Adds the first unit test suite, covering the stable, client-free logic across the domains.

## What's tested
- `internal/misc` — UUID check, label merge, UID↔Identifier, object instantiation/ownership guards
- `internal/kubevim/network` — `IpBelongsToCidr`
- `network/kubeovn` — vpc/vlan/subnet ⇄ nfv converters, IP-version round-trip, format helpers
- `network/sriov` — OVS CNI config rendering, NAD → nfv network
- `flavour/kubevirt` — flavour ⇄ instancetype/preference round-trip, name/id helpers
- `compute/kubevirt` — running-state derivation, flavour/image id extraction, interface binding mapping, network/interface lookups

## Approach
- Stdlib `testing` (table-driven) + `testify` for assertions. Not Ginkgo/envtest — this isn't a controller-runtime codebase.
- Scope is pure functions only. Managers hold concrete `*Clientset` fields and aren't injectable today; testing them is deferred to the planned controller-runtime + cached-client migration (fake client), so no throwaway mocking is added now.
- Rationale documented in `docs/testing.md`.

CI already runs these via the existing `test` job (`make test`); no workflow change.