### PR TITLE
Serve k8s access through a shared controller-runtime cache

### DIFF
--- a/dist/chart/Chart.yaml
+++ b/dist/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: kube-vim
 description: A Helm chart for Kube-NFV kube-vim installation
-version: 0.0.5 # chart packaging version; bump on any chart change, released via chart/v* tag
+version: 0.0.6 # chart packaging version; bump on any chart change, released via chart/v* tag
 # App release the chart deploys by default. Drives the image tag (see _helpers.tpl).
 # Bump manually to a published kube-vim release before cutting a chart release.
 appVersion: "0.0.1"

--- a/dist/chart/templates/role.yaml
+++ b/dist/chart/templates/role.yaml
@@ -50,6 +50,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/dist/manifests/kubevim.yaml
+++ b/dist/manifests/kubevim.yaml
@@ -83,6 +83,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/docs/k8s-client-caching.md
+++ b/docs/k8s-client-caching.md
@@ -1,0 +1,117 @@
+# Kubernetes Client Caching
+
+## Overview
+
+Kube-vim accesses Kubernetes through a single shared controller-runtime
+`cluster.Cluster`. Reads are served from a watch-synced in-memory cache, writes go
+straight to the apiserver, and a small number of strongly-consistent reads use an
+uncached reader. All domain managers receive their client by injection instead of
+building their own typed clientsets.
+
+## Background
+
+### The problem
+
+Every domain manager used to build its own typed clientset from a shared
+`*rest.Config` and call the apiserver live on every request:
+
+- Duplicated clients and transports (the kubevirt, k8s and net-attach clientsets were
+  each constructed more than once), each with its own connection pool and rate
+  limiter. `rest.Config` was left untuned.
+- Read amplification: list-all-then-filter-by-UID lookups, unscoped cluster-wide
+  Lists, and an N+1 fan-out in `ListComputeResources` (one List plus a VMI Get and a
+  pod List per VM) that also ran on every Prometheus scrape via the telemetry
+  collectors.
+- Managers held concrete `*Clientset` fields, so they could not be exercised with
+  fakes in unit tests.
+
+### Why a cache is compatible with a stateless VIM
+
+Kube-vim is stateless: all resource state lives in Kubernetes objects. A read cache
+does not change that. It is a watch-synced replica of apiserver state, not an
+authoritative store. Writes still go to the apiserver and Kubernetes objects remain
+the source of truth; the cache only serves reads faster and offloads the apiserver.
+
+## Design
+
+### Shared cluster
+
+`internal/k8s` builds the shared infrastructure once, in the composition root
+(`internal/kubevim/manager.go`):
+
+- `BuildScheme()` registers every API group kube-vim touches: core and storage
+  (client-go builtins), kubevirt core and instancetype, CDI, kube-ovn and
+  net-attach.
+- `NewCluster()` builds a controller-runtime `cluster.Cluster`. It exposes:
+  - `GetClient()`: a cache-backed reader plus a direct writer. Managers use this for
+    Get/List (cache) and Create/Update/Patch/Delete (apiserver).
+  - `GetAPIReader()`: an uncached reader that always hits the apiserver. Used only
+    where a strongly-consistent read is required.
+  - `GetCache()`: started once in `Start`, gated by `WaitForCacheSync` before the
+    northbound server begins serving.
+
+The `rest.Config` is tuned once (raised QPS/Burst, a `kube-vim` user agent). No global
+request timeout is set, because that would cap the cache's long-lived watch
+connections; per-call context deadlines are used instead.
+
+### Per-type cache scope
+
+The cache is scoped to the configured namespace and restricted to kube-nfv-owned
+objects, with two deliberate exceptions:
+
+| Type | Cached | Selector / scope | Why |
+|---|---|---|---|
+| VirtualMachine, VirtualMachineInstance | yes | namespace + managed-by | owned |
+| VirtualMachineInstancetype, VirtualMachinePreference | yes | namespace + managed-by | owned |
+| Vpc, Vlan, Subnet (kube-ovn, cluster-scoped) | yes | managed-by, cluster-wide | owned |
+| NetworkAttachmentDefinition | yes | namespace + managed-by | owned |
+| DataVolume, VolumeImportSource | yes | namespace + managed-by | owned |
+| Pod | yes | namespace only, no label filter | virt-launcher pods carry kubevirt labels, not managed-by; hot path (launcher info and every scrape) |
+| StorageClass (cluster-scoped) | no | read via apiReader | not owned and read rarely; keeps a cluster-wide StorageClass watch off the cache |
+
+### Read-after-write policy
+
+Cache reads are eventually consistent: a write reaches the cache only when the watch
+delivers it back, a short moment later. Two situations need a stronger guarantee and
+use `GetAPIReader()`:
+
+- **Awaiting a just-created VMI.** After creating a VM, the compute manager polls the
+  uncached reader until the VMI exists (`waitForVmi`), rather than watching or reading
+  a cold cache.
+- **Management-network reconciliation.** `EnsureManagementNetwork` reads objects that
+  may pre-exist without the managed-by label and then adds it. Those objects are not
+  in the managed-by-filtered cache, so all its reads use the uncached reader; label
+  updates are applied as merge patches.
+
+Delete preconditions (reading an object to validate it before deleting) read from the
+cache and accept the brief eventual-consistency window. The flavour manager avoids the
+precondition entirely by deleting via a label-scoped `DeleteAllOf`, which also keeps
+the ownership guard without a read.
+
+### Managers
+
+Managers no longer construct clients. Each constructor takes a `client.Client` (and a
+`client.Reader` where an uncached read is needed) plus its config. This is also what
+makes managers testable against `sigs.k8s.io/controller-runtime/pkg/client/fake`.
+
+The kubevirt typed clientset was removed entirely. It was only needed for the two VM
+readiness watches, which are now a poll of the uncached reader. If VM subresources
+(start/stop, console, migrate) are ever added, they will need the kubevirt clientset
+or its REST client reintroduced, since `client.Client` does CRUD only.
+
+## RBAC
+
+The cache lists and watches every cached type, so each needs `list` and `watch`. All
+owned types were already granted `verbs: ["*"]`. The one addition is `watch` on
+`pods` in the compute-manager Role (it previously had only `get` and `list`), required
+because the pod informer does list plus watch. StorageClass is read through the
+uncached reader and needs only `get`/`list`, already granted.
+
+## Operator notes
+
+- Readiness: the process does not serve gRPC until the cache has synced
+  (`WaitForCacheSync`).
+- Memory: the cache holds only kube-nfv-owned objects (plus namespace pods), so its
+  footprint tracks the number of managed resources.
+- A missing `watch` grant on any cached type surfaces as the cache failing to sync or
+  a List returning a forbidden error; check the Role/ClusterRole first.

--- a/go.mod
+++ b/go.mod
@@ -24,9 +24,9 @@ require (
 	go.uber.org/zap v1.27.0
 	google.golang.org/grpc v1.82.1
 	google.golang.org/protobuf v1.36.11
-	k8s.io/api v0.34.1
-	k8s.io/apimachinery v0.34.1
-	k8s.io/client-go v0.34.1
+	k8s.io/api v0.34.3
+	k8s.io/apimachinery v0.34.3
+	k8s.io/client-go v0.34.3
 	kubevirt.io/api v1.6.2
 	kubevirt.io/client-go v1.6.2
 	kubevirt.io/containerized-data-importer-api v1.63.1
@@ -38,6 +38,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
+	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/go-kit/log v0.2.1 // indirect
@@ -60,7 +61,9 @@ require (
 	github.com/go-openapi/swag/yamlutils v0.25.1 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/google/btree v1.1.3 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
+	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
@@ -87,20 +90,23 @@ require (
 	golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546 // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
+	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/term v0.43.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	golang.org/x/time v0.13.0 // indirect
+	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/apiextensions-apiserver v0.34.1 // indirect
+	k8s.io/apiextensions-apiserver v0.34.3 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.31.0 // indirect
 	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 // indirect
 	kubevirt.io/controller-lifecycle-operator-sdk/api v0.2.4 // indirect
+	sigs.k8s.io/controller-runtime v0.22.5 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -36,7 +36,10 @@ github.com/emicklei/go-restful/v3 v3.13.0 h1:C4Bl2xDndpU6nJ4bc1jXd+uTmYPVUwkD6bF
 github.com/emicklei/go-restful/v3 v3.13.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/evanphx/json-patch v4.12.0+incompatible h1:4onqiflcdA9EOZ4RxV643DvftH5pOlLGNtQ5lPWQu84=
 github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
+github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjTM0wiaDU=
+github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
@@ -130,6 +133,8 @@ github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiu
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
+github.com/google/btree v1.1.3 h1:CVpQJjYgC4VbzxeGVHfvZrv1ctoYCAI8vbl07Fcxlyg=
+github.com/google/btree v1.1.3/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
 github.com/google/gnostic-models v0.7.0 h1:qwTtogB15McXDaNqTZdzPJRHvaVJlAl+HVQnLmJEJxo=
 github.com/google/gnostic-models v0.7.0/go.mod h1:whL5G0m6dmc5cPxKc5bdKdEN3UjI7OUGxBlw57miDrQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
@@ -235,6 +240,7 @@ github.com/onsi/ginkgo/v2 v2.17.2/go.mod h1:nP2DPOQoNsQmsVyv5rDA8JkXQoCs6goXIvr/
 github.com/onsi/ginkgo/v2 v2.19.0/go.mod h1:rlwLi9PilAFJ8jCg9UE1QP6VBpd6/xj3SRC0d6TU0To=
 github.com/onsi/ginkgo/v2 v2.21.0 h1:7rg/4f3rB88pb5obDgNZrNHrQ4e6WpjonchcpuBRnZM=
 github.com/onsi/ginkgo/v2 v2.21.0/go.mod h1:7Du3c42kxCUegi0IImZ1wUQzMBVecgIHjR1C+NkhLQo=
+github.com/onsi/ginkgo/v2 v2.22.0 h1:Yed107/8DjTr0lKCNt7Dn8yQ6ybuDRQoMGrNFKzMfHg=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
@@ -258,6 +264,7 @@ github.com/onsi/gomega v1.33.0/go.mod h1:+925n5YtiFsLzzafLUHzVMBpvvRAzrydIBiSIxj
 github.com/onsi/gomega v1.33.1/go.mod h1:U4R44UsT+9eLIaYRB2a5qajjtQYn0hauxvRm16AVYg0=
 github.com/onsi/gomega v1.35.1 h1:Cwbd75ZBPxFSuZ6T+rN/WCb/gOc6YgFBXLlZLhC7Ds4=
 github.com/onsi/gomega v1.35.1/go.mod h1:PvZbdDc8J6XJEpDK4HCuRBm8a6Fzp9/DmhC9C7yFlog=
+github.com/onsi/gomega v1.36.1 h1:bJDPBO7ibjxcbHMgSCoo4Yj18UWbKDlLwX1x9sybDcw=
 github.com/openshift/custom-resource-status v1.1.2 h1:C3DL44LEbvlbItfd8mT5jWrqPfHnSOQoQf/sypqA6A4=
 github.com/openshift/custom-resource-status v1.1.2/go.mod h1:DB/Mf2oTeiAmVVX1gN+NEqweonAPY0TKUwADizj8+ZA=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
@@ -606,6 +613,8 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gomodules.xyz/jsonpatch/v2 v2.4.0 h1:Ci3iUJyx9UeRx7CeFN8ARgGbkESwJK+KB9lLcWxY/Zw=
+gomodules.xyz/jsonpatch/v2 v2.4.0/go.mod h1:AH3dM2RI6uoBZxn3LVrfvJ3E0/9dG4cSrbuBJT4moAY=
 gonum.org/v1/gonum v0.17.0 h1:VbpOemQlsSMrYmn7T2OUvQ4dqxQXU+ouZFQsZOx50z4=
 gonum.org/v1/gonum v0.17.0/go.mod h1:El3tOrEuMpv2UdMrbNlKEh9vd86bmQ6vqIcDwxEOc1E=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
@@ -665,13 +674,21 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 k8s.io/api v0.23.3/go.mod h1:w258XdGyvCmnBj/vGzQMj6kzdufJZVUwEM1U2fRJwSQ=
 k8s.io/api v0.34.1 h1:jC+153630BMdlFukegoEL8E/yT7aLyQkIVuwhmwDgJM=
 k8s.io/api v0.34.1/go.mod h1:SB80FxFtXn5/gwzCoN6QCtPD7Vbu5w2n1S0J5gFfTYk=
+k8s.io/api v0.34.3 h1:D12sTP257/jSH2vHV2EDYrb16bS7ULlHpdNdNhEw2S4=
+k8s.io/api v0.34.3/go.mod h1:PyVQBF886Q5RSQZOim7DybQjAbVs8g7gwJNhGtY5MBk=
 k8s.io/apiextensions-apiserver v0.34.1 h1:NNPBva8FNAPt1iSVwIE0FsdrVriRXMsaWFMqJbII2CI=
 k8s.io/apiextensions-apiserver v0.34.1/go.mod h1:hP9Rld3zF5Ay2Of3BeEpLAToP+l4s5UlxiHfqRaRcMc=
+k8s.io/apiextensions-apiserver v0.34.3 h1:p10fGlkDY09eWKOTeUSioxwLukJnm+KuDZdrW71y40g=
+k8s.io/apiextensions-apiserver v0.34.3/go.mod h1:aujxvqGFRdb/cmXYfcRTeppN7S2XV/t7WMEc64zB5A0=
 k8s.io/apimachinery v0.23.3/go.mod h1:BEuFMMBaIbcOqVIJqNZJXGFTP4W6AycEpb5+m/97hrM=
 k8s.io/apimachinery v0.34.1 h1:dTlxFls/eikpJxmAC7MVE8oOeP1zryV7iRyIjB0gky4=
 k8s.io/apimachinery v0.34.1/go.mod h1:/GwIlEcWuTX9zKIg2mbw0LRFIsXwrfoVxn+ef0X13lw=
+k8s.io/apimachinery v0.34.3 h1:/TB+SFEiQvN9HPldtlWOTp0hWbJ+fjU+wkxysf/aQnE=
+k8s.io/apimachinery v0.34.3/go.mod h1:/GwIlEcWuTX9zKIg2mbw0LRFIsXwrfoVxn+ef0X13lw=
 k8s.io/client-go v0.34.1 h1:ZUPJKgXsnKwVwmKKdPfw4tB58+7/Ik3CrjOEhsiZ7mY=
 k8s.io/client-go v0.34.1/go.mod h1:kA8v0FP+tk6sZA0yKLRG67LWjqufAoSHA2xVGKw9Of8=
+k8s.io/client-go v0.34.3 h1:wtYtpzy/OPNYf7WyNBTj3iUA0XaBHVqhv4Iv3tbrF5A=
+k8s.io/client-go v0.34.3/go.mod h1:OxxeYagaP9Kdf78UrKLa3YZixMCfP6bgPwPwNBQBzpM=
 k8s.io/code-generator v0.23.3/go.mod h1:S0Q1JVA+kSzTI1oUvbKAxZY/DYbA/ZUb4Uknog12ETk=
 k8s.io/gengo v0.0.0-20210813121822-485abfe95c7c/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
 k8s.io/gengo v0.0.0-20211129171323-c02415ce4185/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
@@ -697,6 +714,8 @@ kubevirt.io/containerized-data-importer-api v1.63.1 h1:g2I9za0QEscRsQjOOK/MM0fey
 kubevirt.io/containerized-data-importer-api v1.63.1/go.mod h1:VGp35wxpLXU18b7cnEpmcThI3AjcZUSfg/Zfql44U4o=
 kubevirt.io/controller-lifecycle-operator-sdk/api v0.2.4 h1:fZYvD3/Vnitfkx6IJxjLAk8ugnZQ7CXVYcRfkSKmuZY=
 kubevirt.io/controller-lifecycle-operator-sdk/api v0.2.4/go.mod h1:018lASpFYBsYN6XwmA2TIrPCx6e0gviTd/ZNtSitKgc=
+sigs.k8s.io/controller-runtime v0.22.5 h1:v3nfSUMowX/2WMp27J9slwGFyAt7IV0YwBxAkrUr0GE=
+sigs.k8s.io/controller-runtime v0.22.5/go.mod h1:pc5SoYWnWI6I+cBHYYdZ7B6YHZVY5xNfll88JB+vniI=
 sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6/go.mod h1:p4QtZmO4uMYipTQNzagwnNoseA6OxSUutVw05NhYDRs=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=

--- a/internal/k8s/cluster.go
+++ b/internal/k8s/cluster.go
@@ -1,0 +1,40 @@
+package k8s
+
+import (
+	common "github.com/kube-nfv/kube-vim/internal/config"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
+)
+
+// NewCluster builds the controller-runtime cluster.Cluster backing all kube-vim
+// k8s access: cache-backed reads via GetClient, direct writes, and an uncached
+// APIReader (GetAPIReader) for read-after-write paths.
+//
+// The cache is scoped to `namespace` and restricted to kube-nfv-owned objects
+// (managed-by label), with two exceptions:
+//   - pods: virt-launcher pods carry kubevirt labels, not managed-by, so they are
+//     cached namespace-wide with no label filter (hot path: launcher info + scrapes).
+//   - storageclasses: cluster-scoped and unlabelled; never cached — read via APIReader.
+func NewCluster(cfg *rest.Config, namespace string, scheme *runtime.Scheme) (cluster.Cluster, error) {
+	managedSel := labels.SelectorFromSet(labels.Set{common.K8sManagedByLabel: common.KubeNfvName})
+	return cluster.New(cfg, func(o *cluster.Options) {
+		o.Scheme = scheme
+		o.Cache = cache.Options{
+			Scheme:               scheme,
+			DefaultNamespaces:    map[string]cache.Config{namespace: {}},
+			DefaultLabelSelector: managedSel,
+			ByObject: map[client.Object]cache.ByObject{
+				&corev1.Pod{}: {Label: labels.Everything()},
+			},
+		}
+		o.Client.Cache = &client.CacheOptions{
+			DisableFor: []client.Object{&storagev1.StorageClass{}},
+		}
+	})
+}

--- a/internal/k8s/scheme.go
+++ b/internal/k8s/scheme.go
@@ -1,0 +1,36 @@
+package k8s
+
+import (
+	"fmt"
+
+	netattv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	kubeovnv1 "github.com/kube-nfv/kube-vim-api/kube-ovn-api/pkg/apis/kubeovn/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+	instancetypev1beta1 "kubevirt.io/api/instancetype/v1beta1"
+	cdiv1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+)
+
+// BuildScheme returns a runtime.Scheme with every API group kube-vim reads or
+// writes registered, so a single controller-runtime cache/client can serve them.
+func BuildScheme() (*runtime.Scheme, error) {
+	scheme := runtime.NewScheme()
+	adders := []struct {
+		name string
+		fn   func(*runtime.Scheme) error
+	}{
+		{"client-go builtins", clientgoscheme.AddToScheme}, // core (pods, secrets), storage (storageclasses)
+		{"kubevirt core/v1", kubevirtv1.AddToScheme},
+		{"kubevirt instancetype/v1beta1", instancetypev1beta1.AddToScheme},
+		{"cdi core/v1beta1", cdiv1beta1.AddToScheme},
+		{"kube-ovn v1", kubeovnv1.AddToScheme},
+		{"net-attach v1", netattv1.AddToScheme},
+	}
+	for _, a := range adders {
+		if err := a.fn(scheme); err != nil {
+			return nil, fmt.Errorf("register %s scheme: %w", a.name, err)
+		}
+	}
+	return scheme, nil
+}

--- a/internal/kubevim/compute/kubevirt/manager.go
+++ b/internal/kubevim/compute/kubevirt/manager.go
@@ -24,13 +24,10 @@ import (
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 
 	kubevirtv1 "kubevirt.io/api/core/v1"
-	kubevirt "kubevirt.io/client-go/kubevirt"
 	"kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -61,16 +58,20 @@ const (
 )
 
 const (
-	vmiCreationTimeout     = time.Second * 2
-	vmStatusCreatedTimeout = time.Second * 3
+	// vmiCreationTimeout bounds how long AllocateComputeResource waits for KubeVirt
+	// to create the VMI after the VM is created (scheduler + virt-controller).
+	vmiCreationTimeout = time.Second * 30
+	vmiPollInterval    = time.Millisecond * 500
 )
 
 // ipamConfigurationMissingErr moved to errors.go as ErrIPAMConfigurationMissing
 
 // kubevirt manager for allocation and management of the compute resources.
 type manager struct {
-	kubevirtClient *kubevirt.Clientset
-	k8sClient      *kubernetes.Clientset
+	// client serves cache-backed reads and direct writes.
+	client client.Client
+	// apiReader is uncached; used to poll for a just-created VMI (read-after-write).
+	apiReader      client.Reader
 	flavourManager flavour.Manager
 	imageManager   image.Manager
 	networkManager network.Manager
@@ -81,23 +82,16 @@ type manager struct {
 }
 
 func NewComputeManager(
-	k8sConfig *rest.Config,
+	cl client.Client,
+	apiReader client.Reader,
 	cfg *config.K8sConfig,
 	computeCfg *config.ComputeConfig,
 	flavourManager flavour.Manager,
 	imageManager image.Manager,
 	networkManager network.Manager) (*manager, error) {
-	c, err := kubevirt.NewForConfig(k8sConfig)
-	if err != nil {
-		return nil, fmt.Errorf("create kubevirt k8s client: %w", err)
-	}
-	k8sClient, err := kubernetes.NewForConfig(k8sConfig)
-	if err != nil {
-		return nil, fmt.Errorf("create k8s client: %w", err)
-	}
 	return &manager{
-		kubevirtClient: c,
-		k8sClient:      k8sClient,
+		client:         cl,
+		apiReader:      apiReader,
 		flavourManager: flavourManager,
 		imageManager:   imageManager,
 		networkManager: networkManager,
@@ -241,39 +235,84 @@ func (m *manager) AllocateComputeResource(ctx context.Context, req *vivnfm.Alloc
 		}
 	}
 
-	vm, err := m.kubevirtClient.KubevirtV1().VirtualMachines(namespace).Create(ctx, vmSpec, v1.CreateOptions{})
-	if err != nil {
+	if err := m.client.Create(ctx, vmSpec); err != nil {
 		return nil, fmt.Errorf("create kubevirt VirtualMachine '%s': %w", vmName, err)
 	}
-	if err = waitVmiCreatedField(ctx, m.kubevirtClient, vm.Name, namespace); err != nil {
-		return nil, fmt.Errorf("create VMI for VM '%s' (uid: %s): %w", vmName, vm.UID, err)
-	}
-	vmi, err := m.kubevirtClient.KubevirtV1().VirtualMachineInstances(namespace).Get(ctx, vmName, v1.GetOptions{})
+	vmi, err := m.waitForVmi(ctx, vmName, namespace)
 	if err != nil {
-		return nil, fmt.Errorf("get VM instance '%s' (uid: %s): %w", vmName, vm.UID, err)
+		return nil, fmt.Errorf("await VMI for VM '%s' (uid: %s): %w", vmName, vmSpec.UID, err)
 	}
-	virtualCompute, err := nfvVirtualComputeFromKubevirtVm(ctx, m.networkManager, vm, vmi, m.getLauncherInfo(ctx, vmi))
+	virtualCompute, err := nfvVirtualComputeFromKubevirtVm(ctx, m.networkManager, vmSpec, vmi, m.getLauncherInfo(ctx, vmi))
 	if err != nil {
-		return nil, fmt.Errorf("convert kubevirt VM '%s' (uid: %s) to nfv VirtualCompute: %w", vmName, vm.UID, err)
+		return nil, fmt.Errorf("convert kubevirt VM '%s' (uid: %s) to nfv VirtualCompute: %w", vmName, vmSpec.UID, err)
 	}
 	return virtualCompute, nil
 }
 
+// waitForVmi polls the apiserver (uncached, for strong read-after-write) until the
+// VMI for the just-created VM exists, or vmiCreationTimeout elapses.
+func (m *manager) waitForVmi(ctx context.Context, name, namespace string) (*kubevirtv1.VirtualMachineInstance, error) {
+	ctx, cancel := context.WithTimeout(ctx, vmiCreationTimeout)
+	defer cancel()
+	key := client.ObjectKey{Namespace: namespace, Name: name}
+	for {
+		vmi := &kubevirtv1.VirtualMachineInstance{}
+		err := m.apiReader.Get(ctx, key, vmi)
+		if err == nil {
+			return vmi, nil
+		}
+		if !k8s_errors.IsNotFound(err) {
+			return nil, fmt.Errorf("get VirtualMachineInstance '%s': %w", name, err)
+		}
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("VMI '%s' not created after %s: %w", name, vmiCreationTimeout, ctx.Err())
+		case <-time.After(vmiPollInterval):
+		}
+	}
+}
+
 func (m *manager) ListComputeResources(ctx context.Context) ([]*vivnfm.VirtualCompute, error) {
 	namespace := *m.cfg.Namespace
-	vmList, err := m.kubevirtClient.KubevirtV1().VirtualMachines(namespace).List(ctx, v1.ListOptions{
-		LabelSelector: common.ManagedByKubeNfvSelector,
-	})
-	if err != nil {
+	managed := client.MatchingLabels{common.K8sManagedByLabel: common.KubeNfvName}
+	ns := client.InNamespace(namespace)
+
+	vmList := &kubevirtv1.VirtualMachineList{}
+	if err := m.client.List(ctx, vmList, ns, managed); err != nil {
 		return nil, fmt.Errorf("list kubevirt VirtualMachines: %w", err)
 	}
-	res := make([]*vivnfm.VirtualCompute, 0, len(vmList.Items))
-	for _, vm := range vmList.Items {
-		vmi, err := m.kubevirtClient.KubevirtV1().VirtualMachineInstances(namespace).Get(ctx, vm.Name, v1.GetOptions{})
-		if err != nil {
-			return nil, fmt.Errorf("get kubevirt VirtualMachineInstance '%s' (uid: %s): %w", vm.Name, vm.UID, err)
+	// List VMIs and virt-launcher pods once, then join in memory, instead of a
+	// per-VM VMI Get + per-VM pod List (this path also runs on every metrics scrape).
+	vmiList := &kubevirtv1.VirtualMachineInstanceList{}
+	if err := m.client.List(ctx, vmiList, ns, managed); err != nil {
+		return nil, fmt.Errorf("list kubevirt VirtualMachineInstances: %w", err)
+	}
+	vmiByName := make(map[string]*kubevirtv1.VirtualMachineInstance, len(vmiList.Items))
+	for i := range vmiList.Items {
+		vmiByName[vmiList.Items[i].Name] = &vmiList.Items[i]
+	}
+	podList := &corev1.PodList{}
+	if err := m.client.List(ctx, podList, ns); err != nil {
+		return nil, fmt.Errorf("list virt-launcher pods: %w", err)
+	}
+	podsByVmiUID := make(map[string][]*corev1.Pod)
+	for i := range podList.Items {
+		if uid, ok := podList.Items[i].Labels[kubevirtv1.CreatedByLabel]; ok {
+			podsByVmiUID[uid] = append(podsByVmiUID[uid], &podList.Items[i])
 		}
-		vComp, err := nfvVirtualComputeFromKubevirtVm(ctx, m.networkManager, &vm, vmi, m.getLauncherInfo(ctx, vmi))
+	}
+
+	res := make([]*vivnfm.VirtualCompute, 0, len(vmList.Items))
+	for i := range vmList.Items {
+		vm := &vmList.Items[i]
+		vmi, ok := vmiByName[vm.Name]
+		if !ok {
+			// VMI not present yet (VM just created, or brief cache lag). Skip it;
+			// it will appear on a subsequent list rather than failing the whole call.
+			continue
+		}
+		launcher := launcherInfoFromPod(selectLauncherPod(podsByVmiUID[string(vmi.UID)], vmi.Status.NodeName))
+		vComp, err := nfvVirtualComputeFromKubevirtVm(ctx, m.networkManager, vm, vmi, launcher)
 		if err != nil {
 			return nil, fmt.Errorf("convert kubevirt VM '%s' (uid: %s) to nfv VirtualCompute: %w", vm.Name, vm.UID, err)
 		}
@@ -301,26 +340,45 @@ type launcherInfo struct {
 // getLauncherInfo reads the VMI's virt-launcher pod name and per-vNIC host PCI
 // addresses. Best-effort: returns zero values on any error, never fails the caller.
 func (m *manager) getLauncherInfo(ctx context.Context, vmi *kubevirtv1.VirtualMachineInstance) launcherInfo {
-	info := launcherInfo{hostPciByVnic: map[string]string{}}
 	if vmi == nil || vmi.UID == "" {
-		return info
+		return launcherInfo{hostPciByVnic: map[string]string{}}
 	}
-	pods, err := m.k8sClient.CoreV1().Pods(*m.cfg.Namespace).List(ctx, v1.ListOptions{
-		LabelSelector: fmt.Sprintf("%s=%s", kubevirtv1.CreatedByLabel, string(vmi.UID)),
-	})
-	if err != nil || len(pods.Items) == 0 {
-		return info
+	podList := &corev1.PodList{}
+	if err := m.client.List(ctx, podList,
+		client.InNamespace(*m.cfg.Namespace),
+		client.MatchingLabels{kubevirtv1.CreatedByLabel: string(vmi.UID)},
+	); err != nil {
+		return launcherInfo{hostPciByVnic: map[string]string{}}
 	}
-	// Prefer the pod on the VMI's current node (unambiguous during migration).
-	pod := &pods.Items[0]
-	for i := range pods.Items {
-		if pods.Items[i].Spec.NodeName == vmi.Status.NodeName {
-			pod = &pods.Items[i]
-			break
+	pods := make([]*corev1.Pod, 0, len(podList.Items))
+	for i := range podList.Items {
+		pods = append(pods, &podList.Items[i])
+	}
+	return launcherInfoFromPod(selectLauncherPod(pods, vmi.Status.NodeName))
+}
+
+// selectLauncherPod prefers the pod on the given node (unambiguous during
+// migration), else the first pod. Returns nil for an empty set.
+func selectLauncherPod(pods []*corev1.Pod, nodeName string) *corev1.Pod {
+	if len(pods) == 0 {
+		return nil
+	}
+	for _, p := range pods {
+		if p.Spec.NodeName == nodeName {
+			return p
 		}
 	}
-	info.podName = pod.Name
+	return pods[0]
+}
 
+// launcherInfoFromPod parses the virt-launcher pod name and per-vNIC host PCI
+// addresses from the kubevirt network-info annotation.
+func launcherInfoFromPod(pod *corev1.Pod) launcherInfo {
+	info := launcherInfo{hostPciByVnic: map[string]string{}}
+	if pod == nil {
+		return info
+	}
+	info.podName = pod.Name
 	infoJSON, ok := pod.Annotations[kubevirtNetworkInfoAnnotation]
 	if !ok {
 		return info
@@ -342,43 +400,39 @@ func (m *manager) GetComputeResource(ctx context.Context, opts ...compute.GetCom
 	namespace := *m.cfg.Namespace
 	cfg := compute.ApplyGetComputeOpts(opts...)
 	if cfg.Name != "" {
-		vm, err := m.kubevirtClient.KubevirtV1().VirtualMachines(namespace).Get(ctx, cfg.Name, v1.GetOptions{})
-		if err != nil {
+		vm := &kubevirtv1.VirtualMachine{}
+		if err := m.client.Get(ctx, client.ObjectKey{Namespace: namespace, Name: cfg.Name}, vm); err != nil {
 			return nil, fmt.Errorf("get kubevirt VirtualMachine '%s': %w", cfg.Name, err)
 		}
-		vmi, err := m.kubevirtClient.KubevirtV1().VirtualMachineInstances(namespace).Get(ctx, cfg.Name, v1.GetOptions{})
-		if err != nil {
-			return nil, fmt.Errorf("get kubevirt VirtualMachineInstance '%s' (uid: %s): %w", cfg.Name, vm.UID, err)
-		}
-		vComp, err := nfvVirtualComputeFromKubevirtVm(ctx, m.networkManager, vm, vmi, m.getLauncherInfo(ctx, vmi))
-		if err != nil {
-			return nil, fmt.Errorf("convert kubevirt VM '%s' (uid: %s) to nfv VirtualCompute: %w", cfg.Name, vm.UID, err)
-		}
-		return vComp, nil
+		return m.computeFromVM(ctx, vm)
 	} else if cfg.Uid != nil && cfg.Uid.Value != "" {
-		vmList, err := m.kubevirtClient.KubevirtV1().VirtualMachines(namespace).List(ctx, v1.ListOptions{
-			LabelSelector: common.ManagedByKubeNfvSelector,
-		})
-		if err != nil {
+		vmList := &kubevirtv1.VirtualMachineList{}
+		if err := m.client.List(ctx, vmList, client.InNamespace(namespace), client.MatchingLabels{common.K8sManagedByLabel: common.KubeNfvName}); err != nil {
 			return nil, fmt.Errorf("list kubevirt VirtualMachines: %w", err)
 		}
-		for _, vm := range vmList.Items {
-			if vm.UID != misc.IdentifierToUID(cfg.Uid) {
+		for i := range vmList.Items {
+			if vmList.Items[i].UID != misc.IdentifierToUID(cfg.Uid) {
 				continue
 			}
-			vmi, err := m.kubevirtClient.KubevirtV1().VirtualMachineInstances(namespace).Get(ctx, vm.Name, v1.GetOptions{})
-			if err != nil {
-				return nil, fmt.Errorf("get kubevirt VirtualMachineInstance '%s' (uid: %s): %w", vm.Name, vm.UID, err)
-			}
-			vComp, err := nfvVirtualComputeFromKubevirtVm(ctx, m.networkManager, &vm, vmi, m.getLauncherInfo(ctx, vmi))
-			if err != nil {
-				return nil, fmt.Errorf("convert kubevirt VM '%s' (uid: %s) to nfv VirtualCompute: %w", vm.Name, vm.UID, err)
-			}
-			return vComp, nil
+			return m.computeFromVM(ctx, &vmList.Items[i])
 		}
 		return nil, &apperrors.ErrNotFound{Entity: "virtual machine", Identifier: cfg.Uid.Value}
 	}
 	return nil, &apperrors.ErrInvalidArgument{Field: "compute lookup", Reason: "either name or uid must be specified"}
+}
+
+// computeFromVM resolves the VMI and launcher info for a VM (from the cache) and
+// converts it to a vivnfm.VirtualCompute.
+func (m *manager) computeFromVM(ctx context.Context, vm *kubevirtv1.VirtualMachine) (*vivnfm.VirtualCompute, error) {
+	vmi := &kubevirtv1.VirtualMachineInstance{}
+	if err := m.client.Get(ctx, client.ObjectKey{Namespace: vm.Namespace, Name: vm.Name}, vmi); err != nil {
+		return nil, fmt.Errorf("get kubevirt VirtualMachineInstance '%s' (uid: %s): %w", vm.Name, vm.UID, err)
+	}
+	vComp, err := nfvVirtualComputeFromKubevirtVm(ctx, m.networkManager, vm, vmi, m.getLauncherInfo(ctx, vmi))
+	if err != nil {
+		return nil, fmt.Errorf("convert kubevirt VM '%s' (uid: %s) to nfv VirtualCompute: %w", vm.Name, vm.UID, err)
+	}
+	return vComp, nil
 }
 
 func (m *manager) DeleteComputeResource(ctx context.Context, opts ...compute.GetComputeOpt) error {
@@ -387,11 +441,13 @@ func (m *manager) DeleteComputeResource(ctx context.Context, opts ...compute.Get
 	if err != nil {
 		return fmt.Errorf("get virtual machine for deletion: %w", err)
 	}
-	if err = m.kubevirtClient.KubevirtV1().VirtualMachines(namespace).Delete(ctx, vm.GetComputeName(), v1.DeleteOptions{}); err != nil {
+	vmObj := &kubevirtv1.VirtualMachine{ObjectMeta: v1.ObjectMeta{Name: vm.GetComputeName(), Namespace: namespace}}
+	if err = m.client.Delete(ctx, vmObj); err != nil {
 		return fmt.Errorf("delete kubevirt VirtualMachine '%s' (id: %s): %w", vm.GetComputeName(), vm.ComputeId.Value, err)
 	}
 	secretName := vm.GetComputeName() + KubevirtVmCloudInitSecretSuffix
-	if err := m.k8sClient.CoreV1().Secrets(namespace).Delete(ctx, secretName, v1.DeleteOptions{}); err != nil && !k8s_errors.IsNotFound(err) {
+	secret := &corev1.Secret{ObjectMeta: v1.ObjectMeta{Name: secretName, Namespace: namespace}}
+	if err := m.client.Delete(ctx, secret); err != nil && !k8s_errors.IsNotFound(err) {
 		return fmt.Errorf("delete cloud-init secret '%s' for VM '%s': %w", secretName, vm.GetComputeName(), err)
 	}
 	return nil
@@ -544,11 +600,11 @@ func (m *manager) createUserDataVolumeWithSecret(ctx context.Context, namespace,
 			"userdata": []byte(userData.Content),
 		},
 	}
-	if _, err := m.k8sClient.CoreV1().Secrets(namespace).Create(ctx, secret, v1.CreateOptions{}); err != nil {
+	if err := m.client.Create(ctx, secret); err != nil {
 		if !k8s_errors.IsAlreadyExists(err) {
 			return nil, nil, fmt.Errorf("create cloud-init secret '%s': %w", secretName, err)
 		}
-		if _, err := m.k8sClient.CoreV1().Secrets(namespace).Update(ctx, secret, v1.UpdateOptions{}); err != nil {
+		if err := m.client.Update(ctx, secret); err != nil {
 			return nil, nil, fmt.Errorf("update cloud-init secret '%s': %w", secretName, err)
 		}
 	}
@@ -884,71 +940,4 @@ func initNetwork(ctx context.Context, netManager network.Manager, networkIpam *v
 				Bridge: &kubevirtv1.InterfaceBridge{},
 			},
 		}, ann, nil
-}
-
-// Waits for the k8s vm object status.created field equal to True.
-// If VM object already exists and has a status.created: true, the function will
-// returns immediately.
-func waitVmiCreatedField(ctx context.Context, client *kubevirt.Clientset, vmName string, namespace string) error {
-	vm, err := client.KubevirtV1().VirtualMachines(namespace).Get(ctx, vmName, v1.GetOptions{})
-	if err != nil && !k8s_errors.IsNotFound(err) {
-		return fmt.Errorf("get kubevirt VM '%s': %w", vmName, err)
-	}
-	// vm exists and vmi already created.
-	if err == nil && vm.Status.Created {
-		return nil
-	}
-
-	vmSelector := fields.OneTermEqualSelector("metadata.name", vmName).String()
-	watcher, err := client.KubevirtV1().VirtualMachines(namespace).Watch(ctx, v1.ListOptions{
-		FieldSelector: vmSelector,
-	})
-	if err != nil {
-		return fmt.Errorf("watch VirtualMachine '%s': %w", vmName, err)
-	}
-	defer watcher.Stop()
-	watchCtx, cancel := context.WithTimeout(ctx, vmStatusCreatedTimeout)
-	defer cancel()
-	for {
-		select {
-		case event := <-watcher.ResultChan():
-			vm, ok := event.Object.(*kubevirtv1.VirtualMachine)
-			if !ok || vm.Name != vmName {
-				continue
-			}
-			if vm.Status.Created {
-				return nil
-			}
-		case <-watchCtx.Done():
-			return fmt.Errorf("VM '%s' status.created is not true after '%s'", vmName, vmStatusCreatedTimeout)
-		}
-	}
-}
-
-func waitVmiObjectCreated(ctx context.Context, client *kubevirt.Clientset, vmName string, namesapce string) (*kubevirtv1.VirtualMachineInstance, error) {
-	fieldSelector := fields.OneTermEqualSelector("metadata.name", vmName).String()
-	watcher, err := client.KubevirtV1().VirtualMachineInstances(namesapce).Watch(ctx, v1.ListOptions{
-		FieldSelector: fieldSelector,
-		Watch:         true,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("watch VirtualMachineInstance '%s': %w", vmName, err)
-	}
-	defer watcher.Stop()
-	watchCtx, cancel := context.WithTimeout(ctx, vmiCreationTimeout)
-	defer cancel()
-	for {
-		select {
-		case event := <-watcher.ResultChan():
-			vmi, ok := event.Object.(*kubevirtv1.VirtualMachineInstance)
-			if !ok {
-				continue
-			}
-			if vmi.Name == vmName {
-				return vmi, nil
-			}
-		case <-watchCtx.Done():
-			return nil, fmt.Errorf("no VMI creation after '%v'", vmiCreationTimeout)
-		}
-	}
 }

--- a/internal/kubevim/flavour/kubevirt/manager.go
+++ b/internal/kubevim/flavour/kubevirt/manager.go
@@ -13,10 +13,8 @@ import (
 	apperrors "github.com/kube-nfv/kube-vim/internal/errors"
 	"github.com/kube-nfv/kube-vim/internal/kubevim/flavour"
 	"github.com/kube-nfv/kube-vim/internal/misc"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/rest"
 	"kubevirt.io/api/instancetype/v1beta1"
-	kubevirt "kubevirt.io/client-go/kubevirt"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -29,20 +27,24 @@ const (
 )
 
 type manager struct {
-	kubevirtClient *kubevirt.Clientset
+	// client serves cache-backed reads and direct writes.
+	client client.Client
+	// apiReader is uncached (hits the apiserver directly); use only where a
+	// strongly-consistent read is required. No flavour path needs it today.
+	apiReader client.Reader
 
 	// Note: Access should be readonly otherwise it might introduce races
 	cfg *config.K8sConfig
 }
 
-func NewFlavourManager(k8sConfig *rest.Config, cfg *config.K8sConfig) (*manager, error) {
-	c, err := kubevirt.NewForConfig(k8sConfig)
-	if err != nil {
-		return nil, fmt.Errorf("create kubevirt client: %w", err)
+func NewFlavourManager(cl client.Client, apiReader client.Reader, cfg *config.K8sConfig) (*manager, error) {
+	if cfg == nil || cfg.Namespace == nil {
+		return nil, &apperrors.ErrInvalidArgument{Field: "k8sConfig.namespace", Reason: "required"}
 	}
 	return &manager{
-		kubevirtClient: c,
-		cfg:            cfg,
+		client:    cl,
+		apiReader: apiReader,
+		cfg:       cfg,
 	}, nil
 }
 
@@ -68,13 +70,11 @@ func (m *manager) CreateFlavour(ctx context.Context, nfvFlavour *vivnfm.VirtualC
 	createCtx, cancel := context.WithTimeout(ctx, CreateFlavourRqTimeout)
 	defer cancel()
 
-	_, err = m.kubevirtClient.InstancetypeV1beta1().VirtualMachineInstancetypes(*m.cfg.Namespace).Create(createCtx, instType, v1.CreateOptions{})
-	if err != nil {
+	if err := m.client.Create(createCtx, instType); err != nil {
 		return nil, fmt.Errorf("create VirtualMachineInstancetype '%s' for flavour '%s': %w", instType.Name, flavourId, err)
 	}
 
-	_, err = m.kubevirtClient.InstancetypeV1beta1().VirtualMachinePreferences(*m.cfg.Namespace).Create(createCtx, instPref, v1.CreateOptions{})
-	if err != nil {
+	if err := m.client.Create(createCtx, instPref); err != nil {
 		return nil, fmt.Errorf("create VirtualMachinePreference '%s' for flavour '%s': %w", instPref.Name, flavourId, err)
 	}
 
@@ -87,11 +87,11 @@ func (m *manager) GetFlavour(ctx context.Context, id *nfvcommon.Identifier) (*vi
 	if id == nil || id.GetValue() == "" {
 		return nil, &apperrors.ErrInvalidArgument{Field: "flavour id", Reason: "required"}
 	}
-	flavourIdSelector := fmt.Sprintf("%s=%s", flavour.K8sFlavourIdLabel, id.GetValue())
-	instTypeList, err := m.kubevirtClient.InstancetypeV1beta1().VirtualMachineInstancetypes(*m.cfg.Namespace).List(ctx, v1.ListOptions{
-		LabelSelector: flavourIdSelector,
-	})
-	if err != nil || instTypeList == nil {
+	idSelector := client.MatchingLabels{flavour.K8sFlavourIdLabel: id.GetValue()}
+	ns := client.InNamespace(*m.cfg.Namespace)
+
+	instTypeList := &v1beta1.VirtualMachineInstancetypeList{}
+	if err := m.client.List(ctx, instTypeList, ns, idSelector); err != nil {
 		return nil, fmt.Errorf("list VirtualMachineInstancetypes for flavour %s: %w", id.GetValue(), err)
 	}
 	if len(instTypeList.Items) == 0 {
@@ -105,12 +105,10 @@ func (m *manager) GetFlavour(ctx context.Context, id *nfvcommon.Identifier) (*vi
 		return nil, &apperrors.ErrK8sObjectNotManagedByKubeNfv{ObjectType: "VirtualMachineInstancetype", ObjectName: instType.Name, ObjectId: string(instType.GetUID())}
 	}
 
-	instPrefList, err := m.kubevirtClient.InstancetypeV1beta1().VirtualMachinePreferences(*m.cfg.Namespace).List(ctx, v1.ListOptions{
-		LabelSelector: flavourIdSelector,
-	})
+	instPrefList := &v1beta1.VirtualMachinePreferenceList{}
 	// It's totaly possible that instancePreference won't exists in the cluster
 	var instPref *v1beta1.VirtualMachinePreference
-	if err == nil && instPrefList != nil && len(instPrefList.Items) == 1 {
+	if err := m.client.List(ctx, instPrefList, ns, idSelector); err == nil && len(instPrefList.Items) == 1 {
 		instPref = &instPrefList.Items[0]
 		if !misc.IsObjectManagedByKubeNfv(instPref) {
 			return nil, &apperrors.ErrK8sObjectNotManagedByKubeNfv{ObjectType: "VirtualMachinePreference", ObjectName: instPref.Name, ObjectId: string(instPref.GetUID())}
@@ -124,17 +122,16 @@ func (m *manager) GetFlavour(ctx context.Context, id *nfvcommon.Identifier) (*vi
 }
 
 func (m *manager) GetFlavours(ctx context.Context) ([]*vivnfm.VirtualComputeFlavour, error) {
-	instTypeList, err := m.kubevirtClient.InstancetypeV1beta1().VirtualMachineInstancetypes(*m.cfg.Namespace).List(ctx, v1.ListOptions{
-		LabelSelector: common.ManagedByKubeNfvSelector,
-	})
-	if err != nil || instTypeList == nil {
+	managed := client.MatchingLabels{common.K8sManagedByLabel: common.KubeNfvName}
+	ns := client.InNamespace(*m.cfg.Namespace)
+
+	instTypeList := &v1beta1.VirtualMachineInstancetypeList{}
+	if err := m.client.List(ctx, instTypeList, ns, managed); err != nil {
 		return nil, fmt.Errorf("list VirtualMachineInstancetypes: %w", err)
 	}
 
-	instPrefList, err := m.kubevirtClient.InstancetypeV1beta1().VirtualMachinePreferences(*m.cfg.Namespace).List(ctx, v1.ListOptions{
-		LabelSelector: common.ManagedByKubeNfvSelector,
-	})
-	if err != nil || instPrefList == nil {
+	instPrefList := &v1beta1.VirtualMachinePreferenceList{}
+	if err := m.client.List(ctx, instPrefList, ns, managed); err != nil {
 		return nil, fmt.Errorf("list VirtualMachinePreferences: %w", err)
 	}
 
@@ -170,17 +167,19 @@ func (m *manager) GetFlavours(ctx context.Context) ([]*vivnfm.VirtualComputeFlav
 }
 
 func (m *manager) DeleteFlavour(ctx context.Context, id *nfvcommon.Identifier) error {
-	_, err := m.GetFlavour(ctx, id)
-	if err != nil {
-		return fmt.Errorf("verify flavour '%s' exists: %w", id.Value, err)
+	ns := client.InNamespace(*m.cfg.Namespace)
+	// Delete only kube-nfv-owned objects carrying this flavour id, so a same-named
+	// object we do not own is never touched. Idempotent: deleting a missing flavour
+	// is a no-op (the preference is optional and may not exist).
+	sel := client.MatchingLabels{
+		common.K8sManagedByLabel:  common.KubeNfvName,
+		flavour.K8sFlavourIdLabel: id.GetValue(),
 	}
-	instTypeName := flavourNameFromId(id.Value)
-	if err := m.kubevirtClient.InstancetypeV1beta1().VirtualMachineInstancetypes(*m.cfg.Namespace).Delete(ctx, instTypeName, v1.DeleteOptions{}); err != nil {
-		return fmt.Errorf("delete VirtualMachineInstancetype '%s' for flavour '%s': %w", instTypeName, id.Value, err)
+	if err := m.client.DeleteAllOf(ctx, &v1beta1.VirtualMachineInstancetype{}, ns, sel); err != nil {
+		return fmt.Errorf("delete VirtualMachineInstancetype for flavour '%s': %w", id.GetValue(), err)
 	}
-	instPrefName := flavourPreferenceNameFromId(id.Value)
-	if err := m.kubevirtClient.InstancetypeV1beta1().VirtualMachinePreferences(*m.cfg.Namespace).Delete(ctx, instPrefName, v1.DeleteOptions{}); err != nil {
-		return fmt.Errorf("delete VirtualMachinePreference '%s' for flavour '%s': %w", instPrefName, id.Value, err)
+	if err := m.client.DeleteAllOf(ctx, &v1beta1.VirtualMachinePreference{}, ns, sel); err != nil {
+		return fmt.Errorf("delete VirtualMachinePreference for flavour '%s': %w", id.GetValue(), err)
 	}
 	return nil
 }

--- a/internal/kubevim/image/cdi/manager.go
+++ b/internal/kubevim/image/cdi/manager.go
@@ -16,10 +16,8 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-	cdi "kubevirt.io/client-go/containerizeddataimporter"
 	"kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -36,30 +34,24 @@ var (
 type cdiManager struct {
 	admin.UnimplementedAdminServer
 
-	cdiClient *cdi.Clientset
-	k8sClient *kubernetes.Clientset
+	// client serves cache-backed reads and direct writes.
+	client client.Client
+	// apiReader is uncached; used for cluster-scoped/unowned reads (StorageClass).
+	apiReader client.Reader
 	cfg       *config.ImageConfig
 	k8sCfg    *config.K8sConfig
 }
 
-func NewCDIImageManager(restConfig *rest.Config, cfg *config.ImageConfig, k8sCfg *config.K8sConfig) (*cdiManager, error) {
+func NewCDIImageManager(cl client.Client, apiReader client.Reader, cfg *config.ImageConfig, k8sCfg *config.K8sConfig) (*cdiManager, error) {
 	if cfg.StorageClass == nil {
 		return nil, &apperrors.ErrInvalidArgument{Field: "config image.StorageClass", Reason: "can't be empty"}
 	}
 	if k8sCfg.Namespace == nil {
 		return nil, &apperrors.ErrInvalidArgument{Field: "config k8s.Namespace", Reason: "can't be nil"}
 	}
-	cdiClient, err := cdi.NewForConfig(restConfig)
-	if err != nil {
-		return nil, fmt.Errorf("create kubevirt CDI k8s client: %w", err)
-	}
-	k8sClient, err := kubernetes.NewForConfig(restConfig)
-	if err != nil {
-		return nil, fmt.Errorf("create kubernetes client: %w", err)
-	}
 	return &cdiManager{
-		cdiClient: cdiClient,
-		k8sClient: k8sClient,
+		client:    cl,
+		apiReader: apiReader,
 		cfg:       cfg,
 		k8sCfg:    k8sCfg,
 	}, nil
@@ -69,14 +61,16 @@ func (m *cdiManager) GetImage(ctx context.Context, id *nfvcommon.Identifier) (*v
 	if id == nil {
 		return nil, &apperrors.ErrInvalidArgument{Field: "id", Reason: "can't be nil"}
 	}
-	images, err := m.cdiClient.CdiV1beta1().VolumeImportSources(*m.k8sCfg.Namespace).List(ctx, v1.ListOptions{})
-	if err != nil {
+	ns := client.InNamespace(*m.k8sCfg.Namespace)
+	managed := client.MatchingLabels{common.K8sManagedByLabel: common.KubeNfvName}
+	visList := &v1beta1.VolumeImportSourceList{}
+	if err := m.client.List(ctx, visList, ns, managed); err != nil {
 		return nil, fmt.Errorf("list CDI VolumeImportSources: %w", err)
 	}
-	var imageVis *v1beta1.VolumeImportSource = nil
-	for _, image := range images.Items {
-		if misc.IdentifierToUID(id) == image.GetUID() {
-			imageVis = &image
+	var imageVis *v1beta1.VolumeImportSource
+	for idx := range visList.Items {
+		if misc.IdentifierToUID(id) == visList.Items[idx].GetUID() {
+			imageVis = &visList.Items[idx]
 			break
 		}
 	}
@@ -84,8 +78,8 @@ func (m *cdiManager) GetImage(ctx context.Context, id *nfvcommon.Identifier) (*v
 		return nil, &apperrors.ErrNotFound{Entity: "software image", Identifier: id.Value}
 	}
 	imgName := imageVis.Name
-	dv, err := m.cdiClient.CdiV1beta1().DataVolumes(*m.k8sCfg.Namespace).Get(ctx, imgName, v1.GetOptions{})
-	if err != nil {
+	dv := &v1beta1.DataVolume{}
+	if err := m.client.Get(ctx, client.ObjectKey{Namespace: *m.k8sCfg.Namespace, Name: imgName}, dv); err != nil {
 		return nil, fmt.Errorf("get CDI DataVolume from image '%s' (id: %s): %w", imgName, id.Value, err)
 	}
 
@@ -97,26 +91,29 @@ func (m *cdiManager) GetImage(ctx context.Context, id *nfvcommon.Identifier) (*v
 }
 
 func (m *cdiManager) ListImages(ctx context.Context) ([]*vivnfm.SoftwareImageInformation, error) {
-	images, err := m.cdiClient.CdiV1beta1().VolumeImportSources(*m.k8sCfg.Namespace).List(ctx, v1.ListOptions{})
-	if err != nil {
+	ns := client.InNamespace(*m.k8sCfg.Namespace)
+	managed := client.MatchingLabels{common.K8sManagedByLabel: common.KubeNfvName}
+	visList := &v1beta1.VolumeImportSourceList{}
+	if err := m.client.List(ctx, visList, ns, managed); err != nil {
 		return nil, fmt.Errorf("list CDI VolumeImportSources: %w", err)
 	}
-	dataVolumes, err := m.cdiClient.CdiV1beta1().DataVolumes(*m.k8sCfg.Namespace).List(ctx, v1.ListOptions{})
-	if err != nil {
+	dvList := &v1beta1.DataVolumeList{}
+	if err := m.client.List(ctx, dvList, ns, managed); err != nil {
 		return nil, fmt.Errorf("list CDI DataVolumes: %w", err)
 	}
 	dataVolumesIdx := make(map[string]*v1beta1.DataVolume)
-	for idx := range dataVolumes.Items {
-		dvRef := &dataVolumes.Items[idx]
+	for idx := range dvList.Items {
+		dvRef := &dvList.Items[idx]
 		dataVolumesIdx[dvRef.Name] = dvRef
 	}
-	res := make([]*vivnfm.SoftwareImageInformation, 0, len(images.Items))
-	for _, img := range images.Items {
+	res := make([]*vivnfm.SoftwareImageInformation, 0, len(visList.Items))
+	for idx := range visList.Items {
+		img := &visList.Items[idx]
 		imgDv, ok := dataVolumesIdx[img.Name]
 		if !ok {
 			continue
 		}
-		nfvImg, err := nfvImageFromCdiDataVolumeVis(imgDv, &img)
+		nfvImg, err := nfvImageFromCdiDataVolumeVis(imgDv, img)
 		if err != nil {
 			continue
 		}
@@ -146,14 +143,19 @@ func (m *cdiManager) DownloadImage(ctx context.Context, req *admin.DownloadImage
 			Source: importSourceType,
 		},
 	}
-	visInst, err := m.cdiClient.CdiV1beta1().VolumeImportSources(*m.k8sCfg.Namespace).Create(ctx, volumeImportSource, v1.CreateOptions{})
-	if err != nil {
+	volumeImportSource.Namespace = *m.k8sCfg.Namespace
+	if err := m.client.Create(ctx, volumeImportSource); err != nil {
 		return nil, fmt.Errorf("create CDI VolumeImportSource: %w", err)
 	}
+	// Cleanup must run even when the request ctx has been canceled (that is often
+	// why we are rolling back), so it uses a ctx detached from cancellation.
+	cleanupCtx := context.WithoutCancel(ctx)
 	cleanupVolumeImportSource := func() error {
-		return m.cdiClient.CdiV1beta1().VolumeImportSources(*m.k8sCfg.Namespace).Delete(ctx, imgName, v1.DeleteOptions{})
+		return m.client.Delete(cleanupCtx, &v1beta1.VolumeImportSource{
+			ObjectMeta: v1.ObjectMeta{Name: imgName, Namespace: *m.k8sCfg.Namespace},
+		})
 	}
-	imageId := misc.UIDToIdentifier(visInst.GetUID())
+	imageId := misc.UIDToIdentifier(volumeImportSource.GetUID())
 
 	// Return non-instantiated image if LazyDownload option presents
 	if req.Options != nil && (req.Options.LazyDownload != nil && *req.Options.LazyDownload == true) {
@@ -166,7 +168,7 @@ func (m *cdiManager) DownloadImage(ctx context.Context, req *admin.DownloadImage
 	if req.Options != nil && (req.Options.StorageClass != nil && *req.Options.StorageClass != "") {
 		storageClassName = *req.Options.StorageClass
 	}
-	storageClass, err := getStorageClass(ctx, storageClassName, m.k8sClient)
+	storageClass, err := getStorageClass(ctx, storageClassName, m.apiReader)
 	if err != nil {
 		cleanupVolumeImportSource()
 		return nil, fmt.Errorf("get storageClass: %w", err)
@@ -191,7 +193,7 @@ func (m *cdiManager) DownloadImage(ctx context.Context, req *admin.DownloadImage
 			Name: imgName,
 			Labels: map[string]string{
 				common.K8sManagedByLabel: common.KubeNfvName,
-				image.K8sImageIdLabel:    string(visInst.GetUID()),
+				image.K8sImageIdLabel:    string(volumeImportSource.GetUID()),
 			},
 			Annotations: dvAnnotations,
 		},
@@ -216,19 +218,23 @@ func (m *cdiManager) DownloadImage(ctx context.Context, req *admin.DownloadImage
 			},
 		},
 	}
-	dvInst, err := m.cdiClient.CdiV1beta1().DataVolumes(*m.k8sCfg.Namespace).Create(ctx, &dataVolume, v1.CreateOptions{})
-	if err != nil {
+	dataVolume.Namespace = *m.k8sCfg.Namespace
+	if err := m.client.Create(ctx, &dataVolume); err != nil {
 		cleanupVolumeImportSource()
 		return nil, fmt.Errorf("create CDI DataVolume for image '%s': %w", imgName, err)
 	}
 	cleanupDataVolume := func() error {
 		cleanupVolumeImportSource()
-		return m.cdiClient.CdiV1beta1().DataVolumes(*m.k8sCfg.Namespace).Delete(ctx, imgName, v1.DeleteOptions{})
+		return m.client.Delete(cleanupCtx, &v1beta1.DataVolume{
+			ObjectMeta: v1.ObjectMeta{Name: imgName, Namespace: *m.k8sCfg.Namespace},
+		})
 	}
 
-	// Update label of volumeImportSource with dv instanceId
-	visInst.ObjectMeta.Labels[K8sDataVolumeIdLabel] = string(dvInst.GetUID())
-	if _, err = m.cdiClient.CdiV1beta1().VolumeImportSources(*m.k8sCfg.Namespace).Update(ctx, visInst, v1.UpdateOptions{}); err != nil {
+	// Label the VolumeImportSource with the DataVolume id. Patch (not Update) to
+	// avoid a resourceVersion conflict on the object we just created.
+	visBase := volumeImportSource.DeepCopy()
+	volumeImportSource.Labels[K8sDataVolumeIdLabel] = string(dataVolume.GetUID())
+	if err := m.client.Patch(ctx, volumeImportSource, client.MergeFrom(visBase)); err != nil {
 		cleanupDataVolume()
 		return nil, fmt.Errorf("update CDI VolumeImportSource label for image '%s': %w", imgName, err)
 	}

--- a/internal/kubevim/image/cdi/utils.go
+++ b/internal/kubevim/image/cdi/utils.go
@@ -13,9 +13,8 @@ import (
 	"github.com/kube-nfv/kube-vim/internal/misc"
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 	"kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // TODO: Add additional image import sources
@@ -53,33 +52,34 @@ func convertToHttpDataVolumeSource(http *admin.HttpSource) (*v1beta1.DataVolumeS
 	return res, nil
 }
 
-// GetStorageClass retrieves a StorageClass by name.
+// getStorageClass retrieves a StorageClass by name.
 // If the name is "default", it returns the cluster's default StorageClass.
-func getStorageClass(ctx context.Context, name string, clientset *kubernetes.Clientset) (*storagev1.StorageClass, error) {
+// StorageClasses are cluster-scoped and not kube-nfv-owned, so this reads through
+// the uncached reader (apiReader) rather than the shared cache.
+func getStorageClass(ctx context.Context, name string, reader client.Reader) (*storagev1.StorageClass, error) {
 	if name == "" {
 		return nil, &apperrors.ErrInvalidArgument{Field: "name", Reason: "can't be empty"}
 	}
-	storageClient := clientset.StorageV1().StorageClasses()
 
 	if name != "default" {
 		// Get StorageClass by exact name
-		sc, err := storageClient.Get(ctx, name, metav1.GetOptions{})
-		if err != nil {
+		sc := &storagev1.StorageClass{}
+		if err := reader.Get(ctx, client.ObjectKey{Name: name}, sc); err != nil {
 			return nil, fmt.Errorf("failed to get storage class %q: %w", name, err)
 		}
 		return sc, nil
 	}
 	// If "default", find the StorageClass annotated as default
-	scList, err := storageClient.List(ctx, metav1.ListOptions{})
-	if err != nil {
+	scList := &storagev1.StorageClassList{}
+	if err := reader.List(ctx, scList); err != nil {
 		return nil, fmt.Errorf("failed to list storage classes: %w", err)
 	}
 
-	for _, sc := range scList.Items {
-		annotations := sc.Annotations
+	for idx := range scList.Items {
+		annotations := scList.Items[idx].Annotations
 		if annotations["storageclass.kubernetes.io/is-default-class"] == "true" ||
 			annotations["storageclass.beta.kubernetes.io/is-default-class"] == "true" {
-			return &sc, nil
+			return &scList.Items[idx], nil
 		}
 	}
 

--- a/internal/kubevim/manager.go
+++ b/internal/kubevim/manager.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/kube-nfv/kube-vim/internal/config/kubevim"
 	apperrors "github.com/kube-nfv/kube-vim/internal/errors"
+	"github.com/kube-nfv/kube-vim/internal/k8s"
 	"github.com/kube-nfv/kube-vim/internal/kubevim/compute"
 	kubevirt_compute "github.com/kube-nfv/kube-vim/internal/kubevim/compute/kubevirt"
 	"github.com/kube-nfv/kube-vim/internal/kubevim/flavour"
@@ -24,6 +25,15 @@ import (
 	"go.uber.org/zap"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
+)
+
+const (
+	// k8sClientQPS/Burst raise client-go's conservative defaults (5/10) for the
+	// shared cluster client; watch traffic is served by the cache, not per-call.
+	k8sClientQPS   = 50
+	k8sClientBurst = 100
+	k8sUserAgent   = "kube-vim"
 )
 
 // Main kubevim object. It is stand as a mediator between different kubevim components like
@@ -38,6 +48,10 @@ type kubevimManager struct {
 	flavourMgr   flavour.Manager
 	computeMgr   compute.Manager
 	telemetryMgr *telemetry.Manager
+
+	// cluster hosts the shared scheme, cache-backed client and APIReader used by
+	// all managers. Its cache must be started (Start) and synced before serving.
+	cluster cluster.Cluster
 
 	nbServer *server.NorthboundServer
 }
@@ -60,21 +74,39 @@ func NewKubeVimManager(cfg *config.Config, logger *zap.Logger) (*kubevimManager,
 			return nil, fmt.Errorf("get k8s inClusterConfig: %w", err)
 		}
 	}
+	// Tune the shared config. Note: no global rest.Config.Timeout is set; it would
+	// cap the cache's long-lived watch connections. Per-call deadlines are used instead.
+	k8sConfig.QPS = k8sClientQPS
+	k8sConfig.Burst = k8sClientBurst
+	k8sConfig.UserAgent = k8sUserAgent
+
+	scheme, err := k8s.BuildScheme()
+	if err != nil {
+		return nil, fmt.Errorf("build k8s scheme: %w", err)
+	}
+	if cfg.K8s == nil || cfg.K8s.Namespace == nil {
+		return nil, &apperrors.ErrInvalidArgument{Field: "k8s.namespace", Reason: "cannot be nil"}
+	}
+	cl, err := k8s.NewCluster(k8sConfig, *cfg.K8s.Namespace, scheme)
+	if err != nil {
+		return nil, fmt.Errorf("build shared k8s cluster: %w", err)
+	}
 
 	mgr := &kubevimManager{
-		logger: logger,
-		cfg:    cfg,
+		logger:  logger,
+		cfg:     cfg,
+		cluster: cl,
 	}
-	if err := mgr.initImageManager(k8sConfig, cfg.Image, cfg.K8s); err != nil {
+	if err := mgr.initImageManager(cfg.Image, cfg.K8s); err != nil {
 		return nil, fmt.Errorf("configure image manager: %w", err)
 	}
-	if err := mgr.initNetworkManager(k8sConfig, cfg.K8s); err != nil {
+	if err := mgr.initNetworkManager(cfg.K8s); err != nil {
 		return nil, fmt.Errorf("initialize network manager: %w", err)
 	}
-	if err := mgr.initFlavourManager(k8sConfig, cfg.K8s); err != nil {
+	if err := mgr.initFlavourManager(cfg.K8s); err != nil {
 		return nil, fmt.Errorf("initialize flavour manager: %w", err)
 	}
-	if err := mgr.initComputeManager(k8sConfig, cfg.K8s, cfg.Compute); err != nil {
+	if err := mgr.initComputeManager(cfg.K8s, cfg.Compute); err != nil {
 		return nil, fmt.Errorf("initialize compute manager: %w", err)
 	}
 	if err := mgr.initTelemetryManager(cfg.Monitoring); err != nil {
@@ -90,6 +122,18 @@ func (m *kubevimManager) Start(ctx context.Context) {
 	errCh := make(chan error, 1) // Buffered to prevent goroutine leaks
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
+
+	// Start the shared cache and block until it has synced before serving, so
+	// managers never read from a cold cache.
+	go func() {
+		if err := m.cluster.Start(ctx); err != nil {
+			errCh <- fmt.Errorf("start k8s cluster cache: %w", err)
+		}
+	}()
+	if !m.cluster.GetCache().WaitForCacheSync(ctx) {
+		m.logger.Error("k8s cache failed to sync; kube-vim manager will terminate")
+		return
+	}
 
 	if m.cfg != nil && m.cfg.Network != nil {
 		if err := m.networkMgr.EnsureManagementNetwork(ctx, m.cfg.Network.ManagementNetwork); err != nil {
@@ -124,12 +168,12 @@ func (m *kubevimManager) Start(ctx context.Context) {
 	m.logger.Info("Kubevim manager shutdown completed")
 }
 
-func (m *kubevimManager) initImageManager(k8sConfig *rest.Config, cfg *config.ImageConfig, k8sCfg *config.K8sConfig) error {
+func (m *kubevimManager) initImageManager(cfg *config.ImageConfig, k8sCfg *config.K8sConfig) error {
 	if cfg == nil {
 		return &apperrors.ErrInvalidArgument{Field: "imageConfig", Reason: "cannot be nil"}
 	}
 	var err error
-	m.imageMgr, err = cdiimmage.NewCDIImageManager(k8sConfig, cfg, k8sCfg)
+	m.imageMgr, err = cdiimmage.NewCDIImageManager(m.cluster.GetClient(), m.cluster.GetAPIReader(), cfg, k8sCfg)
 	if err != nil {
 		return fmt.Errorf("initialize kubevirt cdi image manager: %w", err)
 	}
@@ -164,11 +208,8 @@ func (m *kubevimManager) initImageManager(k8sConfig *rest.Config, cfg *config.Im
 	*/
 }
 
-func (m *kubevimManager) initNetworkManager(k8sConfig *rest.Config, k8sCfg *config.K8sConfig) error {
-	if k8sConfig == nil {
-		return &apperrors.ErrInvalidArgument{Field: "k8sConfig", Reason: "cannot be nil"}
-	}
-	ovnMgr, err := kubeovn.NewKubeovnNetworkManager(k8sConfig, k8sCfg, m.logger.Named("network.ovn"))
+func (m *kubevimManager) initNetworkManager(k8sCfg *config.K8sConfig) error {
+	ovnMgr, err := kubeovn.NewKubeovnNetworkManager(m.cluster.GetClient(), m.cluster.GetAPIReader(), k8sCfg, m.logger.Named("network.ovn"))
 	if err != nil {
 		return fmt.Errorf("create kubeovn network manager: %w", err)
 	}
@@ -176,7 +217,7 @@ func (m *kubevimManager) initNetworkManager(k8sConfig *rest.Config, k8sCfg *conf
 	if m.cfg.Network != nil {
 		sriovCfg = m.cfg.Network.Sriov
 	}
-	sriovMgr, err := sriov.NewSriovNetworkManager(k8sConfig, k8sCfg, sriovCfg, m.logger.Named("network.sriov"))
+	sriovMgr, err := sriov.NewSriovNetworkManager(m.cluster.GetClient(), k8sCfg, sriovCfg, m.logger.Named("network.sriov"))
 	if err != nil {
 		return fmt.Errorf("create sriov network manager: %w", err)
 	}
@@ -184,24 +225,18 @@ func (m *kubevimManager) initNetworkManager(k8sConfig *rest.Config, k8sCfg *conf
 	return nil
 }
 
-func (m *kubevimManager) initFlavourManager(k8sConfig *rest.Config, cfg *config.K8sConfig) error {
-	if k8sConfig == nil {
-		return &apperrors.ErrInvalidArgument{Field: "k8sConfig", Reason: "cannot be nil"}
-	}
+func (m *kubevimManager) initFlavourManager(cfg *config.K8sConfig) error {
 	var err error
-	m.flavourMgr, err = kubevirt_flavour.NewFlavourManager(k8sConfig, cfg)
+	m.flavourMgr, err = kubevirt_flavour.NewFlavourManager(m.cluster.GetClient(), m.cluster.GetAPIReader(), cfg)
 	if err != nil {
 		return fmt.Errorf("create kubevirt flavour manager: %w", err)
 	}
 	return nil
 }
 
-func (m *kubevimManager) initComputeManager(k8sConfig *rest.Config, cfg *config.K8sConfig, computeCfg *config.ComputeConfig) error {
-	if k8sConfig == nil {
-		return &apperrors.ErrInvalidArgument{Field: "k8sConfig", Reason: "cannot be nil"}
-	}
+func (m *kubevimManager) initComputeManager(cfg *config.K8sConfig, computeCfg *config.ComputeConfig) error {
 	var err error
-	m.computeMgr, err = kubevirt_compute.NewComputeManager(k8sConfig, cfg, computeCfg, m.flavourMgr, m.imageMgr, m.networkMgr)
+	m.computeMgr, err = kubevirt_compute.NewComputeManager(m.cluster.GetClient(), m.cluster.GetAPIReader(), cfg, computeCfg, m.flavourMgr, m.imageMgr, m.networkMgr)
 	if err != nil {
 		return fmt.Errorf("create kubevirt compute manager: %w", err)
 	}

--- a/internal/kubevim/network/kubeovn/manager.go
+++ b/internal/kubevim/network/kubeovn/manager.go
@@ -7,9 +7,7 @@ import (
 	"strconv"
 
 	netattv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
-	netatt_client "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned"
 	kubeovnv1 "github.com/kube-nfv/kube-vim-api/kube-ovn-api/pkg/apis/kubeovn/v1"
-	ovn_client "github.com/kube-nfv/kube-vim-api/kube-ovn-api/pkg/client/clientset/versioned"
 	nfvcommon "github.com/kube-nfv/kube-vim-api/pkg/apis"
 	vivnfm "github.com/kube-nfv/kube-vim-api/pkg/apis/vivnfm"
 	common "github.com/kube-nfv/kube-vim/internal/config"
@@ -20,37 +18,33 @@ import (
 	"go.uber.org/zap"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Will manage kube-vim networking for VNF using kube-ovn
 type manager struct {
-	logger          *zap.Logger
-	kubeOvnClient   *ovn_client.Clientset
-	netAttachClient *netatt_client.Clientset
-	k8sCfg          *config.K8sConfig
+	logger *zap.Logger
+	// client serves cache-backed reads and direct writes for kube-vim-owned objects.
+	client client.Client
+	// apiReader is uncached; used by the management-network reconciliation, which
+	// reads objects that may not yet carry the managed-by label (and so are not in
+	// the cache) before labelling them.
+	apiReader client.Reader
+	k8sCfg    *config.K8sConfig
 }
 
-func NewKubeovnNetworkManager(restConfig *rest.Config, k8sCfg *config.K8sConfig, logger *zap.Logger) (*manager, error) {
+func NewKubeovnNetworkManager(cl client.Client, apiReader client.Reader, k8sCfg *config.K8sConfig, logger *zap.Logger) (*manager, error) {
 	if k8sCfg.Namespace == nil {
 		return nil, &apperrors.ErrInvalidArgument{Field: "config k8s.Namespace", Reason: "can't be nil"}
 	}
 	if logger == nil {
 		logger = zap.NewNop()
 	}
-	ovnC, err := ovn_client.NewForConfig(restConfig)
-	if err != nil {
-		return nil, fmt.Errorf("create kube-ovn k8s client: %w", err)
-	}
-	netAttC, err := netatt_client.NewForConfig(restConfig)
-	if err != nil {
-		return nil, fmt.Errorf("create multus network-attachment-definition k8s client: %w", err)
-	}
 	return &manager{
-		logger:          logger,
-		kubeOvnClient:   ovnC,
-		netAttachClient: netAttC,
-		k8sCfg:          k8sCfg,
+		logger:    logger,
+		client:    cl,
+		apiReader: apiReader,
+		k8sCfg:    k8sCfg,
 	}, nil
 }
 
@@ -99,8 +93,7 @@ func (m *manager) createOverlayNetwork(ctx context.Context, name string, network
 	if err != nil {
 		return nil, fmt.Errorf("convert nfv VirtualNetworkData to kube-ovn Vpc for network '%s': %w", name, err)
 	}
-	createdVpc, err := m.kubeOvnClient.KubeovnV1().Vpcs().Create(ctx, vpc, v1.CreateOptions{})
-	if err != nil {
+	if err := m.client.Create(ctx, vpc); err != nil {
 		return nil, fmt.Errorf("create kube-ovn Vpc k8s object '%s': %w", vpc.Name, err)
 	}
 	subnetIds, err := m.allocateL3Attributes(ctx, vpc.Name, networkData.Layer3Attributes)
@@ -110,9 +103,9 @@ func (m *manager) createOverlayNetwork(ctx context.Context, name string, network
 		return nil, fmt.Errorf("create vpc l3 attributes (resources cleaned up): %w", err)
 	}
 
-	res, err := kubeovnVpcToNfvNetwork(createdVpc, subnetIds)
+	res, err := kubeovnVpcToNfvNetwork(vpc, subnetIds)
 	if err != nil {
-		return nil, fmt.Errorf("convert kubeovn vpc '%s' (id: %s) to nfv VirtualNetwork: %w", createdVpc.Name, createdVpc.GetUID(), err)
+		return nil, fmt.Errorf("convert kubeovn vpc '%s' (id: %s) to nfv VirtualNetwork: %w", vpc.Name, vpc.GetUID(), err)
 	}
 	return res, nil
 }
@@ -124,8 +117,7 @@ func (m *manager) createUnderlayNetwork(ctx context.Context, name string, networ
 	if err != nil {
 		return nil, fmt.Errorf("convert VirtualNetworkData to kubeovn vlan for network '%s': %w", name, err)
 	}
-	createdVlan, err := m.kubeOvnClient.KubeovnV1().Vlans().Create(ctx, vlan, v1.CreateOptions{})
-	if err != nil {
+	if err := m.client.Create(ctx, vlan); err != nil {
 		return nil, fmt.Errorf("create kubeovn vlan '%s': %w", vlan.Name, err)
 	}
 	subnetIds, err := m.allocateL3Attributes(ctx, vlan.Name, networkData.Layer3Attributes)
@@ -135,9 +127,9 @@ func (m *manager) createUnderlayNetwork(ctx context.Context, name string, networ
 		return nil, fmt.Errorf("create vlan l3 attributes (resources cleaned up): %w", err)
 	}
 
-	res, err := kubeovnVlanToNfvNetwork(createdVlan, subnetIds)
+	res, err := kubeovnVlanToNfvNetwork(vlan, subnetIds)
 	if err != nil {
-		return nil, fmt.Errorf("convert kubeovn vlan '%s' (id: %s) to nfv VirtualNetwork: %w", createdVlan.Name, createdVlan.GetUID(), err)
+		return nil, fmt.Errorf("convert kubeovn vlan '%s' (id: %s) to nfv VirtualNetwork: %w", vlan.Name, vlan.GetUID(), err)
 	}
 	return res, nil
 }
@@ -163,14 +155,13 @@ func (m *manager) getOverlayNetwork(ctx context.Context, opts ...network.GetNetw
 	cfg := network.ApplyGetNetworkOpts(opts...)
 	var vpc *kubeovnv1.Vpc
 	if cfg.Name != "" {
-		var err error
-		vpc, err = m.kubeOvnClient.KubeovnV1().Vpcs().Get(ctx, cfg.Name, v1.GetOptions{})
-		if err != nil {
+		vpc = &kubeovnv1.Vpc{}
+		if err := m.client.Get(ctx, client.ObjectKey{Name: cfg.Name}, vpc); err != nil {
 			return nil, fmt.Errorf("get kubeovn vpc '%s': %w", cfg.Name, err)
 		}
 	} else if cfg.Uid != nil && cfg.Uid.Value != "" {
-		vpcList, err := m.kubeOvnClient.KubeovnV1().Vpcs().List(ctx, v1.ListOptions{})
-		if err != nil {
+		vpcList := &kubeovnv1.VpcList{}
+		if err := m.client.List(ctx, vpcList, client.MatchingLabels{common.K8sManagedByLabel: common.KubeNfvName}); err != nil {
 			return nil, fmt.Errorf("list kubeovn vpcs for id '%s': %w", cfg.Uid.Value, err)
 		}
 		uid := misc.IdentifierToUID(cfg.Uid)
@@ -208,14 +199,13 @@ func (m *manager) getUnderlayNetwork(ctx context.Context, opts ...network.GetNet
 	cfg := network.ApplyGetNetworkOpts(opts...)
 	var vlan *kubeovnv1.Vlan
 	if cfg.Name != "" {
-		var err error
-		vlan, err = m.kubeOvnClient.KubeovnV1().Vlans().Get(ctx, cfg.Name, v1.GetOptions{})
-		if err != nil {
+		vlan = &kubeovnv1.Vlan{}
+		if err := m.client.Get(ctx, client.ObjectKey{Name: cfg.Name}, vlan); err != nil {
 			return nil, fmt.Errorf("get kubeovn vlan '%s': %w", cfg.Name, err)
 		}
 	} else if cfg.Uid != nil && cfg.Uid.Value != "" {
-		vlanList, err := m.kubeOvnClient.KubeovnV1().Vlans().List(ctx, v1.ListOptions{})
-		if err != nil {
+		vlanList := &kubeovnv1.VlanList{}
+		if err := m.client.List(ctx, vlanList, client.MatchingLabels{common.K8sManagedByLabel: common.KubeNfvName}); err != nil {
 			return nil, fmt.Errorf("list kubeovn vlans for id '%s': %w", cfg.Uid.Value, err)
 		}
 		uid := misc.IdentifierToUID(cfg.Uid)
@@ -249,32 +239,59 @@ func (m *manager) getUnderlayNetwork(ctx context.Context, opts ...network.GetNet
 }
 
 func (m *manager) ListNetworks(ctx context.Context) ([]*vivnfm.VirtualNetwork, error) {
-	netList, err := m.kubeOvnClient.KubeovnV1().Vpcs().List(ctx, v1.ListOptions{
-		LabelSelector: common.ManagedByKubeNfvSelector,
-	})
-	if err != nil {
+	managed := client.MatchingLabels{common.K8sManagedByLabel: common.KubeNfvName}
+	vpcList := &kubeovnv1.VpcList{}
+	if err := m.client.List(ctx, vpcList, managed); err != nil {
 		return nil, fmt.Errorf("list kubeovn vpcs: %w", err)
 	}
-	vlanList, err := m.kubeOvnClient.KubeovnV1().Vlans().List(ctx, v1.ListOptions{
-		LabelSelector: common.ManagedByKubeNfvSelector,
-	})
-	if err != nil {
+	vlanList := &kubeovnv1.VlanList{}
+	if err := m.client.List(ctx, vlanList, managed); err != nil {
 		return nil, fmt.Errorf("list kubeovn vlans: %w", err)
 	}
-	res := make([]*vivnfm.VirtualNetwork, 0, len(netList.Items)+len(vlanList.Items))
-	for _, vpc := range netList.Items {
-		netName := vpc.Name
-		net, err := m.GetNetwork(ctx, network.GetNetworkByName(netName))
+	// List every managed subnet once and index by name, so each network's
+	// Status.Subnets resolves to ids from memory instead of a per-subnet Get.
+	subnetList := &kubeovnv1.SubnetList{}
+	if err := m.client.List(ctx, subnetList, managed); err != nil {
+		return nil, fmt.Errorf("list kubeovn subnets: %w", err)
+	}
+	subnetIdByName := make(map[string]*nfvcommon.Identifier, len(subnetList.Items))
+	for idx := range subnetList.Items {
+		subnetIdByName[subnetList.Items[idx].Name] = misc.UIDToIdentifier(subnetList.Items[idx].GetUID())
+	}
+	resolveSubnetIds := func(subnetNames []string) ([]*nfvcommon.Identifier, error) {
+		ids := make([]*nfvcommon.Identifier, 0, len(subnetNames))
+		for _, sn := range subnetNames {
+			id, ok := subnetIdByName[sn]
+			if !ok {
+				return nil, &apperrors.ErrNotFound{Entity: "kubeovn subnet", Identifier: sn}
+			}
+			ids = append(ids, id)
+		}
+		return ids, nil
+	}
+
+	res := make([]*vivnfm.VirtualNetwork, 0, len(vpcList.Items)+len(vlanList.Items))
+	for idx := range vpcList.Items {
+		vpc := &vpcList.Items[idx]
+		ids, err := resolveSubnetIds(vpc.Status.Subnets)
 		if err != nil {
-			return nil, fmt.Errorf("get kubeovn vpc network '%s' (id: %s): %w", netName, vpc.GetUID(), err)
+			return nil, fmt.Errorf("resolve subnets for vpc '%s' (id: %s): %w", vpc.Name, vpc.GetUID(), err)
+		}
+		net, err := kubeovnVpcToNfvNetwork(vpc, ids)
+		if err != nil {
+			return nil, fmt.Errorf("convert kubeovn vpc '%s' (id: %s) to nfv VirtualNetwork: %w", vpc.Name, vpc.GetUID(), err)
 		}
 		res = append(res, net)
 	}
-	for _, vlan := range vlanList.Items {
-		netName := vlan.Name
-		net, err := m.GetNetwork(ctx, network.GetNetworkByName(netName))
+	for idx := range vlanList.Items {
+		vlan := &vlanList.Items[idx]
+		ids, err := resolveSubnetIds(vlan.Status.Subnets)
 		if err != nil {
-			return nil, fmt.Errorf("get kubeovn vlan network '%s' (id: %s): %w", netName, vlan.GetUID(), err)
+			return nil, fmt.Errorf("resolve subnets for vlan '%s' (id: %s): %w", vlan.Name, vlan.GetUID(), err)
+		}
+		net, err := kubeovnVlanToNfvNetwork(vlan, ids)
+		if err != nil {
+			return nil, fmt.Errorf("convert kubeovn vlan '%s' (id: %s) to nfv VirtualNetwork: %w", vlan.Name, vlan.GetUID(), err)
 		}
 		res = append(res, net)
 	}
@@ -294,11 +311,13 @@ func (m *manager) DeleteNetwork(ctx context.Context, opts ...network.GetNetworkO
 		}
 	}
 	if net.NetworkType == nfvcommon.NetworkType_NETWORK_TYPE_OVERLAY {
-		if err = m.kubeOvnClient.KubeovnV1().Vpcs().Delete(ctx, *net.NetworkResourceName, v1.DeleteOptions{}); err != nil {
+		vpc := &kubeovnv1.Vpc{ObjectMeta: v1.ObjectMeta{Name: *net.NetworkResourceName}}
+		if err = m.client.Delete(ctx, vpc); err != nil {
 			return fmt.Errorf("delete kubeovn vpc '%s' (id: %s): %w", *net.NetworkResourceName, net.NetworkResourceId.Value, err)
 		}
 	} else if net.NetworkType == nfvcommon.NetworkType_NETWORK_TYPE_UNDERLAY {
-		if err = m.kubeOvnClient.KubeovnV1().Vlans().Delete(ctx, *net.NetworkResourceName, v1.DeleteOptions{}); err != nil {
+		vlan := &kubeovnv1.Vlan{ObjectMeta: v1.ObjectMeta{Name: *net.NetworkResourceName}}
+		if err = m.client.Delete(ctx, vlan); err != nil {
 			return fmt.Errorf("delete kubeovn vlan '%s' (id: %s): %w", *net.NetworkResourceName, net.NetworkResourceId.Value, err)
 		}
 	} else {
@@ -341,41 +360,41 @@ func (m *manager) CreateSubnet(ctx context.Context, name string, subnetData *viv
 		subnet.Labels[network.K8sNetworkTypeLabel] = vnet.NetworkType.String()
 	}
 	netAttachName := formatNetAttachName(subnet.GetName())
-	_, err = m.netAttachClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(*m.k8sCfg.Namespace).Create(
-		ctx,
-		&netattv1.NetworkAttachmentDefinition{
-			ObjectMeta: v1.ObjectMeta{
-				Name: netAttachName,
-				Labels: map[string]string{
-					common.K8sManagedByLabel:   common.KubeNfvName,
-					network.K8sSubnetNameLabel: subnet.GetName(),
-				},
+	nad := &netattv1.NetworkAttachmentDefinition{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      netAttachName,
+			Namespace: *m.k8sCfg.Namespace,
+			Labels: map[string]string{
+				common.K8sManagedByLabel:   common.KubeNfvName,
+				network.K8sSubnetNameLabel: subnet.GetName(),
 			},
-			Spec: netattv1.NetworkAttachmentDefinitionSpec{
-				Config: formatNetAttachConfig(netAttachName, *m.k8sCfg.Namespace),
-			},
-		}, v1.CreateOptions{})
-	if err != nil {
+		},
+		Spec: netattv1.NetworkAttachmentDefinitionSpec{
+			Config: formatNetAttachConfig(netAttachName, *m.k8sCfg.Namespace),
+		},
+	}
+	if err := m.client.Create(ctx, nad); err != nil {
 		return nil, fmt.Errorf("create multus network-attachment-definition for subnet '%s': %w", subnet.GetName(), err)
 	}
 	subnet.Spec.Provider = "ovn"
 	subnet.Labels[network.K8sSubnetNetAttachNameLabel] = netAttachName
 
 	cleanupNetAttach := func() error {
-		return m.netAttachClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(*m.k8sCfg.Namespace).Delete(ctx, netAttachName, v1.DeleteOptions{})
+		return m.client.Delete(context.WithoutCancel(ctx), &netattv1.NetworkAttachmentDefinition{
+			ObjectMeta: v1.ObjectMeta{Name: netAttachName, Namespace: *m.k8sCfg.Namespace},
+		})
 	}
 
-	createdSubnet, err := m.kubeOvnClient.KubeovnV1().Subnets().Create(ctx, subnet, v1.CreateOptions{})
-	if err != nil {
+	if err := m.client.Create(ctx, subnet); err != nil {
 		cleanupNetAttach()
 		return nil, fmt.Errorf("create kubeovn subnet '%s': %w", subnet.GetName(), err)
 	}
 
-	nfvSubnet, err := nfvNetworkSubnetFromKubeovnSubnet(createdSubnet)
+	nfvSubnet, err := nfvNetworkSubnetFromKubeovnSubnet(subnet)
 	if err != nil {
 		// Subnet deletion should also delete nettwork attachment
-		m.DeleteSubnet(ctx, network.GetSubnetByUid(misc.UIDToIdentifier(createdSubnet.GetUID())))
-		return nil, fmt.Errorf("convert created kubeovn subnet '%s' (id: %s) to vivnfm.NetworkSubnet (subnet will be deleted): %w", createdSubnet.GetName(), createdSubnet.GetUID(), err)
+		m.DeleteSubnet(ctx, network.GetSubnetByUid(misc.UIDToIdentifier(subnet.GetUID())))
+		return nil, fmt.Errorf("convert created kubeovn subnet '%s' (id: %s) to vivnfm.NetworkSubnet (subnet will be deleted): %w", subnet.GetName(), subnet.GetUID(), err)
 	}
 	return nfvSubnet, nil
 }
@@ -383,8 +402,8 @@ func (m *manager) CreateSubnet(ctx context.Context, name string, subnetData *viv
 func (m *manager) GetSubnet(ctx context.Context, opts ...network.GetSubnetOpt) (*vivnfm.NetworkSubnet, error) {
 	cfg := network.ApplyGetSubnetOpts(opts...)
 	if cfg.Name != "" {
-		subnet, err := m.kubeOvnClient.KubeovnV1().Subnets().Get(ctx, cfg.Name, v1.GetOptions{})
-		if err != nil {
+		subnet := &kubeovnv1.Subnet{}
+		if err := m.client.Get(ctx, client.ObjectKey{Name: cfg.Name}, subnet); err != nil {
 			return nil, fmt.Errorf("get kubeovn subnet '%s': %w", cfg.Name, err)
 		}
 		res, err := nfvNetworkSubnetFromKubeovnSubnet(subnet)
@@ -393,8 +412,8 @@ func (m *manager) GetSubnet(ctx context.Context, opts ...network.GetSubnetOpt) (
 		}
 		return res, nil
 	} else if cfg.Uid != nil && cfg.Uid.Value != "" {
-		subnetList, err := m.kubeOvnClient.KubeovnV1().Subnets().List(ctx, v1.ListOptions{})
-		if err != nil {
+		subnetList := &kubeovnv1.SubnetList{}
+		if err := m.client.List(ctx, subnetList, client.MatchingLabels{common.K8sManagedByLabel: common.KubeNfvName}); err != nil {
 			return nil, fmt.Errorf("list kubeovn subnets: %w", err)
 		}
 		uid := misc.IdentifierToUID(cfg.Uid)
@@ -410,8 +429,8 @@ func (m *manager) GetSubnet(ctx context.Context, opts ...network.GetSubnetOpt) (
 		}
 		return nil, &apperrors.ErrNotFound{Entity: "kubeovn subnet", Identifier: cfg.Uid.GetValue()}
 	} else if cfg.NetAttachName != "" {
-		netAttach, err := m.netAttachClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(*m.k8sCfg.Namespace).Get(ctx, cfg.NetAttachName, v1.GetOptions{})
-		if err != nil {
+		netAttach := &netattv1.NetworkAttachmentDefinition{}
+		if err := m.client.Get(ctx, client.ObjectKey{Namespace: *m.k8sCfg.Namespace, Name: cfg.NetAttachName}, netAttach); err != nil {
 			return nil, fmt.Errorf("get network attachment definition '%s': %w", cfg.NetAttachName, err)
 		}
 		if !misc.IsObjectManagedByKubeNfv(netAttach) {
@@ -438,10 +457,8 @@ func (m *manager) GetSubnet(ctx context.Context, opts ...network.GetSubnetOpt) (
 }
 
 func (m *manager) ListSubnets(ctx context.Context) ([]*vivnfm.NetworkSubnet, error) {
-	subnetList, err := m.kubeOvnClient.KubeovnV1().Subnets().List(ctx, v1.ListOptions{
-		LabelSelector: common.ManagedByKubeNfvSelector,
-	})
-	if err != nil {
+	subnetList := &kubeovnv1.SubnetList{}
+	if err := m.client.List(ctx, subnetList, client.MatchingLabels{common.K8sManagedByLabel: common.KubeNfvName}); err != nil {
 		return nil, fmt.Errorf("list kubeovn subnets: %w", err)
 	}
 	res := make([]*vivnfm.NetworkSubnet, 0, len(subnetList.Items))
@@ -465,11 +482,13 @@ func (m *manager) DeleteSubnet(ctx context.Context, opts ...network.GetSubnetOpt
 	// The only way to get name from the vivnfm.NetworkSubnet resource is to get it by label.
 	subnetName := subnet.Metadata.Fields[network.K8sSubnetNameLabel]
 
-	if err := m.kubeOvnClient.KubeovnV1().Subnets().Delete(ctx, subnetName, v1.DeleteOptions{}); err != nil {
+	subnetObj := &kubeovnv1.Subnet{ObjectMeta: v1.ObjectMeta{Name: subnetName}}
+	if err := m.client.Delete(ctx, subnetObj); err != nil {
 		return fmt.Errorf("delete kubeovn subnet '%s' (id: %s): %w", subnetName, subnet.ResourceId.Value, err)
 	}
 	// delete multus NetworkAttachmentDefinition
-	if err := m.netAttachClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(*m.k8sCfg.Namespace).Delete(ctx, netAttachName, v1.DeleteOptions{}); err != nil {
+	nad := &netattv1.NetworkAttachmentDefinition{ObjectMeta: v1.ObjectMeta{Name: netAttachName, Namespace: *m.k8sCfg.Namespace}}
+	if err := m.client.Delete(ctx, nad); err != nil {
 		return fmt.Errorf("delete multus NetworkAttachmentDefinition '%s' for subnet '%s': %w", netAttachName, subnet.ResourceId.Value, err)
 	}
 	return nil

--- a/internal/kubevim/network/kubeovn/mgmt.go
+++ b/internal/kubevim/network/kubeovn/mgmt.go
@@ -15,6 +15,7 @@ import (
 	"go.uber.org/zap"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // EnsureManagementNetwork provisions or reconciles the shared management
@@ -104,20 +105,23 @@ func mgmtNetAttachLabels(subnetName string) map[string]string {
 }
 
 func (m *manager) ensureMgmtVpc(ctx context.Context, log *zap.Logger, vpcName string) (*kubeovnv1.Vpc, error) {
-	existing, err := m.kubeOvnClient.KubeovnV1().Vpcs().Get(ctx, vpcName, v1.GetOptions{})
+	// Uncached read: the Vpc may pre-exist without the managed-by label (so it is
+	// not in the cache) and this is exactly where we add that label.
+	existing := &kubeovnv1.Vpc{}
+	err := m.apiReader.Get(ctx, client.ObjectKey{Name: vpcName}, existing)
 	if err == nil {
 		changed, merged := misc.MergeLabels(existing.Labels, mgmtVpcLabels())
 		if !changed {
 			log.Debug("Vpc already exists with required labels")
 			return existing, nil
 		}
+		base := existing.DeepCopy()
 		existing.Labels = merged
-		updated, err := m.kubeOvnClient.KubeovnV1().Vpcs().Update(ctx, existing, v1.UpdateOptions{})
-		if err != nil {
+		if err := m.client.Patch(ctx, existing, client.MergeFrom(base)); err != nil {
 			return nil, fmt.Errorf("patch vpc labels: %w", err)
 		}
 		log.Debug("Patched Vpc labels")
-		return updated, nil
+		return existing, nil
 	}
 	if !k8s_errors.IsNotFound(err) {
 		return nil, fmt.Errorf("get vpc: %w", err)
@@ -130,21 +134,25 @@ func (m *manager) ensureMgmtVpc(ctx context.Context, log *zap.Logger, vpcName st
 		},
 		Spec: kubeovnv1.VpcSpec{},
 	}
-	created, err := m.kubeOvnClient.KubeovnV1().Vpcs().Create(ctx, vpc, v1.CreateOptions{})
-	if err != nil {
+	if err := m.client.Create(ctx, vpc); err != nil {
 		if k8s_errors.IsAlreadyExists(err) {
 			// Race: another caller created it. Re-read to get a stable UID.
-			return m.kubeOvnClient.KubeovnV1().Vpcs().Get(ctx, vpcName, v1.GetOptions{})
+			reread := &kubeovnv1.Vpc{}
+			if err := m.apiReader.Get(ctx, client.ObjectKey{Name: vpcName}, reread); err != nil {
+				return nil, fmt.Errorf("re-read vpc after AlreadyExists: %w", err)
+			}
+			return reread, nil
 		}
 		return nil, fmt.Errorf("create vpc: %w", err)
 	}
 	log.Debug("Created Vpc")
-	return created, nil
+	return vpc, nil
 }
 
 func (m *manager) ensureMgmtSubnet(ctx context.Context, log *zap.Logger, cfg *config.ManagementNetworkConfig, vpcName, vpcUID, subnetName, nadName string) error {
 	required := mgmtSubnetLabels(vpcName, vpcUID, subnetName, nadName)
-	existing, err := m.kubeOvnClient.KubeovnV1().Subnets().Get(ctx, subnetName, v1.GetOptions{})
+	existing := &kubeovnv1.Subnet{}
+	err := m.apiReader.Get(ctx, client.ObjectKey{Name: subnetName}, existing)
 	if err == nil {
 		changed, merged := misc.MergeLabels(existing.Labels, required)
 		if !changed {
@@ -152,8 +160,9 @@ func (m *manager) ensureMgmtSubnet(ctx context.Context, log *zap.Logger, cfg *co
 				zap.String("cidr", existing.Spec.CIDRBlock))
 			return nil
 		}
+		base := existing.DeepCopy()
 		existing.Labels = merged
-		if _, err := m.kubeOvnClient.KubeovnV1().Subnets().Update(ctx, existing, v1.UpdateOptions{}); err != nil {
+		if err := m.client.Patch(ctx, existing, client.MergeFrom(base)); err != nil {
 			return fmt.Errorf("patch subnet labels: %w", err)
 		}
 		log.Debug("Patched Subnet labels", zap.String("cidr", existing.Spec.CIDRBlock))
@@ -184,7 +193,7 @@ func (m *manager) ensureMgmtSubnet(ctx context.Context, log *zap.Logger, cfg *co
 	if cfg.ExcludeIps != nil && len(*cfg.ExcludeIps) > 0 {
 		sub.Spec.ExcludeIps = append([]string(nil), (*cfg.ExcludeIps)...)
 	}
-	if _, err := m.kubeOvnClient.KubeovnV1().Subnets().Create(ctx, sub, v1.CreateOptions{}); err != nil {
+	if err := m.client.Create(ctx, sub); err != nil {
 		if k8s_errors.IsAlreadyExists(err) {
 			return nil
 		}
@@ -196,16 +205,18 @@ func (m *manager) ensureMgmtSubnet(ctx context.Context, log *zap.Logger, cfg *co
 
 func (m *manager) ensureMgmtNetAttach(ctx context.Context, log *zap.Logger, subnetName, nadName, nadNamespace string) error {
 	required := mgmtNetAttachLabels(subnetName)
-	nadClient := m.netAttachClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(nadNamespace)
-	existing, err := nadClient.Get(ctx, nadName, v1.GetOptions{})
+	nadKey := client.ObjectKey{Namespace: nadNamespace, Name: nadName}
+	existing := &netattv1.NetworkAttachmentDefinition{}
+	err := m.apiReader.Get(ctx, nadKey, existing)
 	if err == nil {
 		changed, merged := misc.MergeLabels(existing.Labels, required)
 		if !changed {
 			log.Debug("NetworkAttachmentDefinition already exists with required labels")
 			return nil
 		}
+		base := existing.DeepCopy()
 		existing.Labels = merged
-		if _, err := nadClient.Update(ctx, existing, v1.UpdateOptions{}); err != nil {
+		if err := m.client.Patch(ctx, existing, client.MergeFrom(base)); err != nil {
 			return fmt.Errorf("patch network-attachment-definition labels: %w", err)
 		}
 		log.Debug("Patched NetworkAttachmentDefinition labels")
@@ -225,7 +236,7 @@ func (m *manager) ensureMgmtNetAttach(ctx context.Context, log *zap.Logger, subn
 			Config: formatNetAttachConfig(nadName, nadNamespace),
 		},
 	}
-	if _, err := nadClient.Create(ctx, nad, v1.CreateOptions{}); err != nil {
+	if err := m.client.Create(ctx, nad); err != nil {
 		if k8s_errors.IsAlreadyExists(err) {
 			return nil
 		}

--- a/internal/kubevim/network/sriov/manager.go
+++ b/internal/kubevim/network/sriov/manager.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	netattv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
-	netatt_client "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned"
 	nfvcommon "github.com/kube-nfv/kube-vim-api/pkg/apis"
 	vivnfm "github.com/kube-nfv/kube-vim-api/pkg/apis/vivnfm"
 	common "github.com/kube-nfv/kube-vim/internal/config"
@@ -16,36 +15,33 @@ import (
 	"go.uber.org/zap"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type manager struct {
-	logger          *zap.Logger
-	netAttachClient *netatt_client.Clientset
-	k8sCfg          *config.K8sConfig
-	socketFile      string
+	logger *zap.Logger
+	// client serves cache-backed reads and direct writes.
+	client     client.Client
+	k8sCfg     *config.K8sConfig
+	socketFile string
 }
 
-func NewSriovNetworkManager(restConfig *rest.Config, k8sCfg *config.K8sConfig, sriovCfg *config.SriovNetworkConfig, logger *zap.Logger) (*manager, error) {
+func NewSriovNetworkManager(cl client.Client, k8sCfg *config.K8sConfig, sriovCfg *config.SriovNetworkConfig, logger *zap.Logger) (*manager, error) {
 	if k8sCfg.Namespace == nil {
 		return nil, &apperrors.ErrInvalidArgument{Field: "config k8s.Namespace", Reason: "can't be nil"}
 	}
 	if logger == nil {
 		logger = zap.NewNop()
 	}
-	netAttC, err := netatt_client.NewForConfig(restConfig)
-	if err != nil {
-		return nil, fmt.Errorf("create multus network-attachment-definition k8s client: %w", err)
-	}
 	var socketFile string
 	if sriovCfg != nil && sriovCfg.SocketFile != nil {
 		socketFile = *sriovCfg.SocketFile
 	}
 	return &manager{
-		logger:          logger,
-		netAttachClient: netAttC,
-		k8sCfg:          k8sCfg,
-		socketFile:      socketFile,
+		logger:     logger,
+		client:     cl,
+		k8sCfg:     k8sCfg,
+		socketFile: socketFile,
 	}, nil
 }
 
@@ -92,24 +88,18 @@ func (m *manager) CreateNetwork(ctx context.Context, name string, networkData *v
 		},
 	}
 
-	created, err := m.netAttachClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(*m.k8sCfg.Namespace).Create(ctx, nad, v1.CreateOptions{})
-	if err != nil {
+	if err := m.client.Create(ctx, nad); err != nil {
 		return nil, fmt.Errorf("create SR-IOV NetworkAttachmentDefinition '%s': %w", name, err)
 	}
-	return nadToNfvNetwork(created)
+	return nadToNfvNetwork(nad)
 }
 
 func (m *manager) GetNetwork(ctx context.Context, opts ...network.GetNetworkOpt) (*vivnfm.VirtualNetwork, error) {
 	cfg := network.ApplyGetNetworkOpts(opts...)
 
-	labelSel := fmt.Sprintf("%s=%s,%s=%s",
-		common.K8sManagedByLabel, common.KubeNfvName,
-		network.K8sNetworkTypeLabel, nfvcommon.NetworkType_NETWORK_TYPE_SRIOV.String(),
-	)
-
 	if cfg.Name != "" {
-		nad, err := m.netAttachClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(*m.k8sCfg.Namespace).Get(ctx, cfg.Name, v1.GetOptions{})
-		if err != nil {
+		nad := &netattv1.NetworkAttachmentDefinition{}
+		if err := m.client.Get(ctx, client.ObjectKey{Namespace: *m.k8sCfg.Namespace, Name: cfg.Name}, nad); err != nil {
 			if k8s_errors.IsNotFound(err) {
 				return nil, &apperrors.ErrNotFound{Entity: fmt.Sprintf("SR-IOV network '%s'", cfg.Name)}
 			}
@@ -121,8 +111,8 @@ func (m *manager) GetNetwork(ctx context.Context, opts ...network.GetNetworkOpt)
 		return nadToNfvNetwork(nad)
 	}
 	if cfg.Uid != nil && cfg.Uid.Value != "" {
-		list, err := m.netAttachClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(*m.k8sCfg.Namespace).List(ctx, v1.ListOptions{LabelSelector: labelSel})
-		if err != nil {
+		list := &netattv1.NetworkAttachmentDefinitionList{}
+		if err := m.client.List(ctx, list, client.InNamespace(*m.k8sCfg.Namespace), m.sriovSelector()); err != nil {
 			return nil, fmt.Errorf("list SR-IOV NetworkAttachmentDefinitions: %w", err)
 		}
 		for i := range list.Items {
@@ -135,13 +125,17 @@ func (m *manager) GetNetwork(ctx context.Context, opts ...network.GetNetworkOpt)
 	return nil, &apperrors.ErrInvalidArgument{Field: "GetNetworkOpt", Reason: "name or uid required"}
 }
 
+// sriovSelector matches kube-nfv-owned SR-IOV NetworkAttachmentDefinitions.
+func (m *manager) sriovSelector() client.MatchingLabels {
+	return client.MatchingLabels{
+		common.K8sManagedByLabel:    common.KubeNfvName,
+		network.K8sNetworkTypeLabel: nfvcommon.NetworkType_NETWORK_TYPE_SRIOV.String(),
+	}
+}
+
 func (m *manager) ListNetworks(ctx context.Context) ([]*vivnfm.VirtualNetwork, error) {
-	labelSel := fmt.Sprintf("%s=%s,%s=%s",
-		common.K8sManagedByLabel, common.KubeNfvName,
-		network.K8sNetworkTypeLabel, nfvcommon.NetworkType_NETWORK_TYPE_SRIOV.String(),
-	)
-	list, err := m.netAttachClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(*m.k8sCfg.Namespace).List(ctx, v1.ListOptions{LabelSelector: labelSel})
-	if err != nil {
+	list := &netattv1.NetworkAttachmentDefinitionList{}
+	if err := m.client.List(ctx, list, client.InNamespace(*m.k8sCfg.Namespace), m.sriovSelector()); err != nil {
 		return nil, fmt.Errorf("list SR-IOV NetworkAttachmentDefinitions: %w", err)
 	}
 	result := make([]*vivnfm.VirtualNetwork, 0, len(list.Items))
@@ -164,7 +158,10 @@ func (m *manager) DeleteNetwork(ctx context.Context, opts ...network.GetNetworkO
 	if net.NetworkResourceName == nil {
 		return &apperrors.ErrInvalidArgument{Field: "networkResourceName", Reason: "cannot be nil"}
 	}
-	if err := m.netAttachClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(*m.k8sCfg.Namespace).Delete(ctx, *net.NetworkResourceName, v1.DeleteOptions{}); err != nil {
+	nad := &netattv1.NetworkAttachmentDefinition{
+		ObjectMeta: v1.ObjectMeta{Name: *net.NetworkResourceName, Namespace: *m.k8sCfg.Namespace},
+	}
+	if err := m.client.Delete(ctx, nad); err != nil {
 		return fmt.Errorf("delete SR-IOV NetworkAttachmentDefinition '%s': %w", *net.NetworkResourceName, err)
 	}
 	return nil


### PR DESCRIPTION
Refs #28.

Moves all Kubernetes access behind a single controller-runtime `cluster.Cluster`
instead of each manager building its own typed clientset. Reads are served from a
watch-synced cache, writes go straight to the apiserver, and the few reads that need
strong consistency use the uncached `APIReader`. Managers now receive their client by
injection, which also unblocks testing them with the controller-runtime fake client.

### What changed

- `internal/k8s`: `BuildScheme()` (all API groups) and `NewCluster()` build the shared
  scheme + cache-backed client + APIReader. Wired in the composition root, with tuned
  QPS/Burst/user-agent and a `WaitForCacheSync` gate before serving.
- Cache is namespace-scoped and restricted to kube-nfv-owned objects, except pods
  (virt-launcher pods aren't managed-by labelled) and StorageClass (read uncached).
- Per manager:
  - flavour: cache reads; delete via label-scoped `DeleteAllOf` (keeps the ownership
    guard without a precondition read).
  - image/cdi: cache reads; StorageClass via APIReader.
  - sriov / kubeovn: cache reads; kube-ovn management-network reconcile uses the
    APIReader (it reads objects before labelling them) and merge patches.
  - compute: cache reads; the two VM readiness watches are replaced by an APIReader
    poll, which lets the kubevirt clientset be dropped entirely.
- Fixed the `ListComputeResources` and `ListNetworks` N+1 fan-outs (they now list once
  and join in memory; the compute one runs on every metrics scrape).
- RBAC: added `watch` on pods (the pod informer needs list+watch).
- Docs: new `docs/k8s-client-caching.md`; refreshed CLAUDE.md.

### Notes

- Delete preconditions read from the cache and accept a brief eventual-consistency
  window; flavour avoids it entirely via `DeleteAllOf`.
- The cache warms lazily (informers start on first use), so the first read per type
  pays the initial sync inline.
- No functional clientset remains; only pre-existing dead code (`image/cdi.go`,
  `internal/k8s/resource_manager.go`) still references clientsets.

`go build`, `go vet` and `go test ./...` pass.
