### PR TITLE
telemetry: expose controller-runtime rest_client metrics on /metrics

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -54,8 +54,20 @@ method, host}` — kube-vim's own traffic to the Kubernetes API server.
 The `rest_client_*` counter is not emitted by kube-vim: controller-runtime
 collects it in its own package-global `metrics.Registry` (separate from the
 telemetry registry). The `/metrics` handler therefore gathers over both
-registries (`prometheus.Gatherers`); the metric names are disjoint. Request
-latency (`rest_client_request_duration_seconds`) is deliberately **not** exposed:
+registries (`prometheus.Gatherers`); the metric names are disjoint.
+
+Granularity is coarse by design. The only labels are `code` (HTTP status),
+`method` (**HTTP** verb — `GET`/`POST`/`PUT`/`PATCH`/`DELETE`) and `host`
+(apiserver). There is **no** per-endpoint attribution: no URL path, no
+resource/kind, no namespace, and no Kubernetes verb (`list`/`get`/`watch` all
+appear as `GET`). client-go omits the path deliberately to avoid the cardinality
+blow-up of object names/namespaces. So this answers API-traffic *health* —
+request rate, verb mix, error ratio by status, `409`-conflict and `429`-throttle
+rates — but not "requests against pods vs subnets vs datavolumes". Per-resource /
+per-k8s-verb attribution would need the same custom `WrapTransport` RoundTripper
+as latency (bucketing high-cardinality path segments), left as follow-up.
+
+Request latency (`rest_client_request_duration_seconds`) is deliberately **not** exposed:
 controller-runtime's `pkg/metrics` `init` claims client-go's `sync.Once`-guarded
 `metrics.Register` with only the result counter, so registering the latency
 adapters ourselves is a silent no-op. Getting latency would require a custom

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -48,7 +48,19 @@ joined per-object. Datapoint attributes become per-series labels, which can.
 ## Emitted metrics
 
 Operational: gRPC RED (`rpc_server_*` from otelgrpc), `go_*` / `process_*`,
-`kubevim_build_info{version, go_version}`.
+`kubevim_build_info{version, go_version}`, and `rest_client_requests_total{code,
+method, host}` — kube-vim's own traffic to the Kubernetes API server.
+
+The `rest_client_*` counter is not emitted by kube-vim: controller-runtime
+collects it in its own package-global `metrics.Registry` (separate from the
+telemetry registry). The `/metrics` handler therefore gathers over both
+registries (`prometheus.Gatherers`); the metric names are disjoint. Request
+latency (`rest_client_request_duration_seconds`) is deliberately **not** exposed:
+controller-runtime's `pkg/metrics` `init` claims client-go's `sync.Once`-guarded
+`metrics.Register` with only the result counter, so registering the latency
+adapters ourselves is a silent no-op. Getting latency would require a custom
+`rest.Config.WrapTransport` RoundTripper (must skip long-lived watches) and is
+left as follow-up.
 
 Correlation (value always `1`):
 
@@ -110,7 +122,8 @@ by a 10s timeout; a backend error is logged and skipped, never failing the scrap
 - `internal/kubevim/telemetry/` — `provider.go` (OTEL MeterProvider + OTEL
   Prometheus exporter into a dedicated `prometheus.Registry` + Go/process
   collectors), `server.go` (`/metrics` `http.Server` with `ReadHeaderTimeout` +
-  graceful `Shutdown`), `info.go` (the correlation gauges), `metrics.go`
+  graceful `Shutdown`, gathering over the telemetry registry and
+  controller-runtime's `metrics.Registry`), `info.go` (the correlation gauges), `metrics.go`
   (build-info), `manager.go` (lifecycle; inert no-op provider when disabled).
 - `internal/kubevim/manager.go` — `initTelemetryManager`; the MeterProvider is
   threaded into the northbound server for otelgrpc; the metrics server runs as a
@@ -140,7 +153,7 @@ pod annotations are intentionally not emitted — the Operator ignores them.
    `--set vim.metrics.serviceMonitor.enabled=true` when running the Operator).
 2. `curl <vim-pod>:9095/metrics` → expect `kubevim_compute_info`,
    `kubevim_vnic_info`, `kubevim_network_info`, `rpc_server_*`, `go_*`,
-   `kubevim_build_info`.
+   `kubevim_build_info`, `rest_client_requests_total`.
 3. Confirm the backends export their own series (KubeVirt/kube-OVN/SR-IOV) and
    that `kubevim_compute_info.compute_name` matches the `name` label on
    `kubevirt_vmi_*` — that shared label is what the recording rules will join on.

--- a/internal/kubevim/telemetry/manager.go
+++ b/internal/kubevim/telemetry/manager.go
@@ -17,6 +17,7 @@ import (
 	metricnoop "go.opentelemetry.io/otel/metric/noop"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.uber.org/zap"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	config "github.com/kube-nfv/kube-vim/internal/config/kubevim"
 	apperrors "github.com/kube-nfv/kube-vim/internal/errors"
@@ -73,11 +74,15 @@ func NewManager(cfg *config.MonitoringConfig, logger *zap.Logger, computeMgr com
 		return nil, err
 	}
 
+	// Serve our registry alongside controller-runtime's (rest_client_* for
+	// kube-vim's apiserver traffic); metric names are disjoint.
+	gatherer := prometheus.Gatherers{registry, ctrlmetrics.Registry}
+
 	return &Manager{
 		logger:   logger,
 		provider: provider,
 		sdk:      provider,
-		server:   newMetricsServer(port, registry),
+		server:   newMetricsServer(port, gatherer),
 		port:     port,
 	}, nil
 }

--- a/internal/kubevim/telemetry/server.go
+++ b/internal/kubevim/telemetry/server.go
@@ -22,10 +22,11 @@ const (
 
 // newMetricsServer builds the Prometheus /metrics HTTP server. A
 // ReadHeaderTimeout is set to protect against slow-loris style stalls; the
-// handler streams from the OTEL-backed registry.
-func newMetricsServer(port int, registry *prometheus.Registry) *http.Server {
+// handler streams from gatherer, which fans out over both the OTEL-backed
+// registry and controller-runtime's registry (see newManager).
+func newMetricsServer(port int, gatherer prometheus.Gatherer) *http.Server {
 	mux := http.NewServeMux()
-	mux.Handle(metricsPath, promhttp.HandlerFor(registry, promhttp.HandlerOpts{
+	mux.Handle(metricsPath, promhttp.HandlerFor(gatherer, promhttp.HandlerOpts{
 		ErrorHandling: promhttp.ContinueOnError,
 	}))
 	return &http.Server{

--- a/internal/kubevim/telemetry/server_test.go
+++ b/internal/kubevim/telemetry/server_test.go
@@ -1,0 +1,41 @@
+package telemetry
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+// The /metrics handler must fan out over both the telemetry registry and
+// controller-runtime's global registry, so a series registered in either shows
+// up on a single scrape. rest_client_requests_total can't be exercised without a
+// real apiserver, so a probe metric stands in for controller-runtime's registry.
+func TestMetricsServerGathersBothRegistries(t *testing.T) {
+	telemetryReg := prometheus.NewRegistry()
+	telemetryReg.MustRegister(prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "kubevim_probe_telemetry",
+	}))
+
+	ctrlProbe := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "kubevim_probe_ctrlruntime",
+	})
+	require.NoError(t, ctrlmetrics.Registry.Register(ctrlProbe))
+	t.Cleanup(func() { ctrlmetrics.Registry.Unregister(ctrlProbe) })
+
+	gatherer := prometheus.Gatherers{telemetryReg, ctrlmetrics.Registry}
+	srv := newMetricsServer(0, gatherer)
+
+	req := httptest.NewRequest("GET", metricsPath, nil)
+	rec := httptest.NewRecorder()
+	srv.Handler.ServeHTTP(rec, req)
+
+	require.Equal(t, 200, rec.Code)
+	body := rec.Body.String()
+	assert.True(t, strings.Contains(body, "kubevim_probe_telemetry"), "telemetry registry series missing")
+	assert.True(t, strings.Contains(body, "kubevim_probe_ctrlruntime"), "controller-runtime registry series missing")
+}


### PR DESCRIPTION
## What

Surface `rest_client_requests_total` on the existing `/metrics` endpoint so operators can see kube-vim's own traffic to the Kubernetes API server (request rate, verb mix, and error/conflict/throttle rates by status code).

controller-runtime already collects this counter in its package-global `metrics.Registry`, separate from the telemetry registry, so it never reached `/metrics`. The handler now gathers over both registries (`prometheus.Gatherers`); the metric names are disjoint.

## Scope / limitations

- Labels are coarse by design: `code` (HTTP status), `method` (HTTP verb), `host` (apiserver). **No** per-endpoint attribution - no path, resource/kind, namespace, or k8s verb (`list`/`get`/`watch` all appear as `GET`). client-go omits the path to avoid cardinality blow-up. Documented in `docs/monitoring.md`.
- Request **latency** (`rest_client_request_duration_seconds`) is not exposed: controller-runtime's `pkg/metrics` init claims client-go's `sync.Once`-guarded `Register` with only the result counter, so registering latency adapters ourselves is a no-op. Latency and per-resource attribution would both need a custom `WrapTransport` RoundTripper - left as follow-up.

## Tests

New `server_test.go` asserts the `/metrics` handler fans out over both registries. The `rest_client_*` counter itself can't be exercised without a real apiserver, so a probe metric stands in.

## Docs

`docs/monitoring.md` updated: emitted-metrics list, the granularity limitation, and the latency/`sync.Once` caveat.

Closes #36. Follow-up test coverage tracked in #37.
